### PR TITLE
fix window.parent override:

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5329,7 +5329,10 @@ Wombat.prototype.initWindowObjProxy = function($wbwindow) {
             return wombat.$wbwindow.WB_wombat_top._WB_wombat_obj_proxy;
           case 'parent':
             var parentProxy = wombat.$wbwindow.parent._WB_wombat_obj_proxy;
-            if (wombat.$wbwindow === wombat.$wbwindow.WB_wombat_top || !parentProxy) {
+            if (
+              wombat.$wbwindow === wombat.$wbwindow.WB_wombat_top ||
+              !parentProxy
+            ) {
               return wombat.$wbwindow.WB_wombat_top._WB_wombat_obj_proxy;
             }
             return parentProxy;

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5608,7 +5608,8 @@ Wombat.prototype.initTopFrame = function($wbwindow) {
     $wbwindow.__WB_top_frame = undefined;
   }
 
-  // Fix .parent only if not embeddable, otherwise leave for accessing embedding window
+  // if not top-replay frame and using auto-fetch workers, register listener
+  // messaging here
   if (!this.wb_opts.embedded && replay_top == $wbwindow) {
     if (this.wbUseAFWorker) {
       var wombat = this;
@@ -5626,6 +5627,7 @@ Wombat.prototype.initTopFrame = function($wbwindow) {
         false
       );
     }
+    //removed to rely on proxy object override to ensure 'parent' and 'top' overriden together
     //$wbwindow.__WB_orig_parent = $wbwindow.parent;
     //$wbwindow.parent = replay_top;
   }

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5328,11 +5328,11 @@ Wombat.prototype.initWindowObjProxy = function($wbwindow) {
           case 'top':
             return wombat.$wbwindow.WB_wombat_top._WB_wombat_obj_proxy;
           case 'parent':
-            var realParent = $wbwindow.parent;
-            if (realParent === $wbwindow.WB_wombat_top) {
-              return $wbwindow.WB_wombat_top._WB_wombat_obj_proxy;
+            var parentProxy = wombat.$wbwindow.parent._WB_wombat_obj_proxy;
+            if (wombat.$wbwindow === wombat.$wbwindow.WB_wombat_top || !parentProxy) {
+              return wombat.$wbwindow.WB_wombat_top._WB_wombat_obj_proxy;
             }
-            return realParent._WB_wombat_obj_proxy;
+            return parentProxy;
         }
         return wombat.defaultProxyGet($wbwindow, prop, ownProps, funCache);
       },
@@ -5592,7 +5592,7 @@ Wombat.prototype.initTopFrame = function($wbwindow) {
 
   $wbwindow.__WB_replay_top = replay_top;
 
-  var real_parent = replay_top.__WB_orig_parent || replay_top.parent;
+  var real_parent = replay_top.parent;
   // Check to ensure top frame is different window and directly accessible (later refactor to support postMessage)
   if (real_parent == $wbwindow || !this.wb_info.is_framed) {
     real_parent = undefined;
@@ -5623,8 +5623,8 @@ Wombat.prototype.initTopFrame = function($wbwindow) {
         false
       );
     }
-    $wbwindow.__WB_orig_parent = $wbwindow.parent;
-    $wbwindow.parent = replay_top;
+    //$wbwindow.__WB_orig_parent = $wbwindow.parent;
+    //$wbwindow.parent = replay_top;
   }
 };
 

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -50,12 +50,12 @@ test('init_top_frame: should set __WB_replay_top correctly', async t => {
   t.true(result, 'The replay top should equal to frames window object');
 });
 
-test('init_top_frame: proxy object top is _WB_replay_top', async t => {
+test('init_top_frame: proxy object of __WB_replay_top is top of window of proxy object', async t => {
   const { sandbox, server } = t.context;
   const result = await sandbox.evaluate(
-    () => window._WB_replay_top === window._WB_wombat_obj_proxy.top
+    () => window.__WB_replay_top._WB_wombat_obj_proxy === window._WB_wombat_obj_proxy.top
   );
-  t.true(result, 'proxy object top should be equal to _WB_replay_top');
+  t.true(result, 'proxy object of __WB_replay_top should be the top of window proxy object');
 });
 
 test('init_top_frame: proxy object parent should equal proxy object top', async t => {

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -50,20 +50,20 @@ test('init_top_frame: should set __WB_replay_top correctly', async t => {
   t.true(result, 'The replay top should equal to frames window object');
 });
 
-test('init_top_frame: should set __WB_orig_parent correctly', async t => {
+test('init_top_frame: proxy object top is _WB_replay_top', async t => {
   const { sandbox, server } = t.context;
   const result = await sandbox.evaluate(
-    () => window.__WB_orig_parent === window.top
+    () => window._WB_replay_top === window._WB_wombat_obj_proxy.top
   );
-  t.true(result, '__WB_orig_parent should equal the actual top');
+  t.true(result, 'proxy object top should be equal to _WB_replay_top');
 });
 
-test('init_top_frame: should set parent to itself (__WB_replay_top)', async t => {
+test('init_top_frame: proxy object parent should equal proxy object top', async t => {
   const { sandbox, server } = t.context;
   const result = await sandbox.evaluate(
-    () => window.parent === window.__WB_replay_top
+    () => window._WB_wombat_obj_proxy.parent === window._WB_wombat_obj_proxy.top
   );
-  t.true(result, 'window.parent should equal to itself (__WB_replay_top)');
+  t.true(result, 'proxy parent should equal to proxy top');
 });
 
 test('WombatLocation: should be added to window as WB_wombat_location', async t => {

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -53,9 +53,14 @@ test('init_top_frame: should set __WB_replay_top correctly', async t => {
 test('init_top_frame: proxy object of __WB_replay_top is top of window of proxy object', async t => {
   const { sandbox, server } = t.context;
   const result = await sandbox.evaluate(
-    () => window.__WB_replay_top._WB_wombat_obj_proxy === window._WB_wombat_obj_proxy.top
+    () =>
+      window.__WB_replay_top._WB_wombat_obj_proxy ===
+      window._WB_wombat_obj_proxy.top
   );
-  t.true(result, 'proxy object of __WB_replay_top should be the top of window proxy object');
+  t.true(
+    result,
+    'proxy object of __WB_replay_top should be the top of window proxy object'
+  );
 });
 
 test('init_top_frame: proxy object parent should equal proxy object top', async t => {


### PR DESCRIPTION
- remove directly setting 'window.parent', as it may result in infinite loops if window object leaks because 'window.top != window.parent' when traversing hierarchy
- fix override of 'window.parent' in object proxy, window.parent overriden only if window.top is also overriden