### PR TITLE
Support for fetching an HTML url (from history page)

### DIFF
--- a/src/autoFetchWorker.js
+++ b/src/autoFetchWorker.js
@@ -107,7 +107,7 @@ function fetchURL(toBeFetched) {
   var url;
   var options;
 
-  if (typeof(toBeFetched) === "object") {
+  if (typeof toBeFetched === 'object') {
     url = toBeFetched.url;
     options = toBeFetched.options;
   } else {
@@ -120,15 +120,9 @@ function fetchURL(toBeFetched) {
 }
 
 function queueOrFetch(toBeFetched) {
-  var url = typeof(toBeFetched) === "object" ?
-            toBeFetched.url :
-            toBeFetched;
+  var url = typeof toBeFetched === 'object' ? toBeFetched.url : toBeFetched;
 
-  if (
-    !url ||
-    url.indexOf(DataURLPrefix) === 0 ||
-    seen[url] != null
-  ) {
+  if (!url || url.indexOf(DataURLPrefix) === 0 || seen[url] != null) {
     return;
   }
   seen[url] = true;

--- a/src/autoFetchWorker.js
+++ b/src/autoFetchWorker.js
@@ -101,27 +101,42 @@ function fetchDoneOrErrored() {
   fetchFromQ();
 }
 
-function fetchURL(urlToBeFetched) {
+function fetchURL(toBeFetched) {
   runningFetches += 1;
-  fetch(urlToBeFetched)
+
+  var url;
+  var options;
+
+  if (typeof(toBeFetched) === "object") {
+    url = toBeFetched.url;
+    options = toBeFetched.options;
+  } else {
+    url = toBeFetched;
+  }
+
+  fetch(url, options)
     .then(fetchDoneOrErrored)
     .catch(fetchDoneOrErrored);
 }
 
-function queueOrFetch(urlToBeFetched) {
+function queueOrFetch(toBeFetched) {
+  var url = typeof(toBeFetched) === "object" ?
+            toBeFetched.url :
+            toBeFetched;
+
   if (
-    !urlToBeFetched ||
-    urlToBeFetched.indexOf(DataURLPrefix) === 0 ||
-    seen[urlToBeFetched] != null
+    !url ||
+    url.indexOf(DataURLPrefix) === 0 ||
+    seen[url] != null
   ) {
     return;
   }
-  seen[urlToBeFetched] = true;
+  seen[url] = true;
   if (runningFetches >= MaxRunningFetches) {
-    queue.push(urlToBeFetched);
+    queue.push(toBeFetched);
     return;
   }
-  fetchURL(urlToBeFetched);
+  fetchURL(toBeFetched);
 }
 
 function fetchFromQ() {

--- a/src/autoFetcher.js
+++ b/src/autoFetcher.js
@@ -138,17 +138,22 @@ AutoFetcher.prototype.justFetch = function(urls) {
  * that this is a page to backing worker
  * @param {Array<string>} url
  */
-AutoFetcher.prototype.fetchAsPage = function(url, title) {
+AutoFetcher.prototype.fetchAsPage = function(url, originalUrl, title) {
   if (!url) {
     return;
   }
 
-  var pageHeader = title ? title.trim() : "true";
+  var headers = {"X-Wombat-History-Page": originalUrl}
+  if (title) {
+    title = encodeURIComponent(title.trim());
+    if (title) {
+      headers['X-Wombat-History-Title'] = title;
+    }
+  }
+
   var fetchData = {
     "url": url,
-    "options": {
-      "headers": {"X-Wombat-History-Page": pageHeader}
-    }
+    "options": {"headers": headers}
   };
 
   this.justFetch([fetchData]);

--- a/src/autoFetcher.js
+++ b/src/autoFetcher.js
@@ -132,33 +132,33 @@ AutoFetcher.prototype.justFetch = function(urls) {
   this.worker.postMessage({ type: 'fetch-all', values: urls });
 };
 
-
 /**
  * Sends the supplied url with extra options to indicate
  * that this is a page to backing worker
- * @param {Array<string>} url
+ * @param {string} url
+ * @param {string} originalUrl
+ * @param {string} [title]
  */
 AutoFetcher.prototype.fetchAsPage = function(url, originalUrl, title) {
   if (!url) {
     return;
   }
 
-  var headers = {"X-Wombat-History-Page": originalUrl}
+  var headers = { 'X-Wombat-History-Page': originalUrl };
   if (title) {
-    title = encodeURIComponent(title.trim());
+    var encodedTitle = encodeURIComponent(title.trim());
     if (title) {
-      headers['X-Wombat-History-Title'] = title;
+      headers['X-Wombat-History-Title'] = encodedTitle;
     }
   }
 
   var fetchData = {
-    "url": url,
-    "options": {"headers": headers}
+    url: url,
+    options: { headers: headers }
   };
 
   this.justFetch([fetchData]);
 };
-
 
 /**
  * Sends a message to backing worker. If deferred is true

--- a/src/autoFetcher.js
+++ b/src/autoFetcher.js
@@ -132,6 +132,29 @@ AutoFetcher.prototype.justFetch = function(urls) {
   this.worker.postMessage({ type: 'fetch-all', values: urls });
 };
 
+
+/**
+ * Sends the supplied url with extra options to indicate
+ * that this is a page to backing worker
+ * @param {Array<string>} url
+ */
+AutoFetcher.prototype.fetchAsPage = function(url, title) {
+  if (!url) {
+    return;
+  }
+
+  var pageHeader = title ? title.trim() : "true";
+  var fetchData = {
+    "url": url,
+    "options": {
+      "headers": {"X-Wombat-History-Page": pageHeader}
+    }
+  };
+
+  this.justFetch([fetchData]);
+};
+
+
 /**
  * Sends a message to backing worker. If deferred is true
  * the message is sent after one tick of the event loop

--- a/src/autoFetcherProxyMode.js
+++ b/src/autoFetcherProxyMode.js
@@ -121,7 +121,7 @@ AutoFetcherProxyMode.prototype.terminate = function() {
 
 /**
  * Sends the supplied array of URLs to the backing worker
- * @param {Array<string>} urls
+ * @param {Array<string>|Array<Object>} urls
  */
 AutoFetcherProxyMode.prototype.justFetch = function(urls) {
   this.postMessage({ type: 'fetch-all', values: urls });
@@ -130,24 +130,25 @@ AutoFetcherProxyMode.prototype.justFetch = function(urls) {
 /**
  * Sends the supplied url with extra options to indicate
  * that this is a page to backing worker
- * @param {Array<string>} url
+ * @param {string} url
+ * @param {string} [title]
  */
 AutoFetcherProxyMode.prototype.fetchAsPage = function(url, title) {
   if (!url) {
     return;
   }
 
-  var headers = {"X-Wombat-History-Page": url}
+  var headers = { 'X-Wombat-History-Page': url };
   if (title) {
-    title = encodeURIComponent(title.trim());
+    var encodedTitle = encodeURIComponent(title.trim());
     if (title) {
-      headers['X-Wombat-History-Title'] = title;
+      headers['X-Wombat-History-Title'] = encodedTitle;
     }
   }
 
   var fetchData = {
-    "url": url,
-    "options": {"headers": headers}
+    url: url,
+    options: { headers: headers }
   };
 
   this.justFetch([fetchData]);
@@ -217,7 +218,10 @@ AutoFetcherProxyMode.prototype.handleMutatedElem = function(elem, accum) {
     case 'style':
       return this.handleMutatedStyleElem(elem, accum);
     case 'link':
-      if (elem.rel === "stylesheet" || (elem.rel === "preload" && elem.as === "style")) {
+      if (
+        elem.rel === 'stylesheet' ||
+        (elem.rel === 'preload' && elem.as === 'style')
+      ) {
         return this.handleMutatedStyleElem(elem, accum);
       }
       break;

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2904,8 +2904,16 @@ Wombat.prototype.overrideHistoryFunc = function(funcName) {
 
     orig_func.call(this, stateObj, title, rewritten_url);
 
+    var origTitle = wombat.$wbwindow.document.title;
+
     if (wombat.WBAutoFetchWorker) {
-      wombat.WBAutoFetchWorker.fetchAsPage(rewritten_url);
+      wombat.$wbwindow.setTimeout(function() {
+        if (!title && wombat.$wbwindow.document.title !== origTitle) {
+          title = wombat.$wbwindow.document.title;
+        }
+
+        wombat.WBAutoFetchWorker.fetchAsPage(rewritten_url, resolvedURL, title);
+      }, 100);
     }
 
     wombat.sendHistoryUpdate(resolvedURL, title);

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2904,8 +2904,8 @@ Wombat.prototype.overrideHistoryFunc = function(funcName) {
 
     orig_func.call(this, stateObj, title, rewritten_url);
 
-    if (wombat.$wbwindow.fetch) {
-      wombat.$wbwindow.fetch(rewritten_url, {"headers": {"X-Wombat-History-Page-Title": title.trim() || url}});
+    if (wombat.WBAutoFetchWorker) {
+      wombat.WBAutoFetchWorker.fetchAsPage(rewritten_url);
     }
 
     wombat.sendHistoryUpdate(resolvedURL, title);

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2904,6 +2904,10 @@ Wombat.prototype.overrideHistoryFunc = function(funcName) {
 
     orig_func.call(this, stateObj, title, rewritten_url);
 
+    if (wombat.$wbwindow.fetch) {
+      wombat.$wbwindow.fetch(rewritten_url, {"headers": {"X-Wombat-History-Page-Title": title.trim() || url}});
+    }
+
     wombat.sendHistoryUpdate(resolvedURL, title);
   };
 

--- a/src/wombatLite.js
+++ b/src/wombatLite.js
@@ -229,6 +229,10 @@ WombatLite.prototype.initAutoFetchWorker = function() {
 };
 
 WombatLite.prototype.initHistoryOverrides = function() {
+  if (this.$wbwindow.self !== this.$wbwindow.top) {
+    return;
+  }
+
   this.overrideHistoryFunc('pushState');
   this.overrideHistoryFunc('replaceState');
   var wombatLite = this;
@@ -258,12 +262,20 @@ WombatLite.prototype.overrideHistoryFunc = function(funcName) {
       return;
     }
 
-    if (wombat.WBAutoFetchWorker) {
-      wombat.WBAutoFetchWorker.fetchAsPage(url);
-    }
+    var origTitle = wombat.$wbwindow.document.title;
 
-    for (var i = 0; i < wombat.historyCB.length; i++) {
-      wombat.historyCB[i](url, title, funcName, stateObj);
+    if (wombat.WBAutoFetchWorker) {
+      wombat.$wbwindow.setTimeout(function() {
+        if (!title && wombat.$wbwindow.document.title !== origTitle) {
+          title = wombat.$wbwindow.document.title;
+        }
+
+        wombat.WBAutoFetchWorker.fetchAsPage(rewritten_url, resolvedURL, title);
+
+        for (var i = 0; i < wombat.historyCB.length; i++) {
+          wombat.historyCB[i](url, title, funcName, stateObj);
+        }
+      }, 100);
     }
   };
 

--- a/src/wombatLite.js
+++ b/src/wombatLite.js
@@ -276,8 +276,8 @@ WombatLite.prototype.overrideHistoryFunc = function(funcName) {
           title
         );
 
-        if (wombatLite.historyCB) {
-          wombatLite.historyCB(
+        if (wombat.historyCB) {
+          wombat.historyCB(
             wombat.$wbwindow.location.href,
             title,
             funcName,
@@ -323,11 +323,11 @@ WombatLite.prototype.wombatInit = function() {
 
   // disable notifications
   this.initDisableNotifications();
-  var wombatLight = this;
+  var wombatLite = this;
   return {
     actual: false,
     setHistoryCB: function(cb) {
-      wombatLight.historyCB = cb;
+      wombatLite.historyCB = cb;
     }
   };
 };

--- a/src/wombatLite.js
+++ b/src/wombatLite.js
@@ -270,7 +270,7 @@ WombatLite.prototype.overrideHistoryFunc = function(funcName) {
           title = wombat.$wbwindow.document.title;
         }
 
-        wombat.WBAutoFetchWorker.fetchAsPage(rewritten_url, resolvedURL, title);
+        wombat.WBAutoFetchWorker.fetchAsPage(wombat.$wbwindow.location.href, title);
 
         for (var i = 0; i < wombat.historyCB.length; i++) {
           wombat.historyCB[i](url, title, funcName, stateObj);

--- a/src/wombatLite.js
+++ b/src/wombatLite.js
@@ -249,17 +249,21 @@ WombatLite.prototype.overrideHistoryFunc = function(funcName) {
   if (!orig_func) return undefined;
 
   this.$wbwindow.history['_orig_' + funcName] = orig_func;
-  var wombatLite = this;
+  var wombat = this;
 
   var rewrittenFunc = function histNewFunc(stateObj, title, url) {
     orig_func.call(this, stateObj, title, url);
 
-    if (wombatLite.$wbwindow.fetch) {
-      wombatLite.$wbwindow.fetch(url, {"headers": {"X-Wombat-History-Page-Title": title.trim() || url}});
+    if (!url) {
+      return;
     }
 
-    for (var i = 0; i < wombatLite.historyCB.length; i++) {
-      wombatLite.historyCB[i](url, title, funcName, stateObj);
+    if (wombat.WBAutoFetchWorker) {
+      wombat.WBAutoFetchWorker.fetchAsPage(url);
+    }
+
+    for (var i = 0; i < wombat.historyCB.length; i++) {
+      wombat.historyCB[i](url, title, funcName, stateObj);
     }
   };
 


### PR DESCRIPTION
Support fetching a page url, via `fetchAsPage` function triggered in wombat on pushState/replaceState. Support queuing not just urls, but objects, which then include fetch url and additional options.
Fetching a page adds special headers:
- `X-Wombat-History-Page` indicating the actual url (in case it is manipulated by service worker)
- `X-Wombat-History-Title` indicating the title of the page, if known.

Proxy mode additions:
- add history pushState/replaceState overrides to trigger fetchAsPage
- support `historyCB` list of callbacks triggered when history changed in proxy mode (since no event sent otherwise)
- To account for title being set possibly after pushState, delay fetchAsPage with slight timeout.
- page fetch does not use `proxy-fetch` prefix to ensure correct cookies are sent.
- Also support queuing messages where fetching is attempted before worker is itself fetched.

General fix:
- For link tags, check if href is for a stylesheet before fetching and attempting to parse as stylesheet.