### PR TITLE
ServiceWorker and Reproducibility Improvements

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -43,6 +43,7 @@ function Wombat($wbwindow, wbinfo) {
     '#',
     'about:',
     'data:',
+    'blob:',
     'mailto:',
     'javascript:',
     '{',
@@ -921,6 +922,9 @@ Wombat.prototype.extractOriginalURL = function(rewrittenUrl) {
   if (index < 0) {
     index = url.indexOf('///', start);
   }
+  if (index < 0) {
+    index = url.indexOf('/blob:', start);
+  }
 
   // extract original url from wburl
   if (index >= 0) {
@@ -936,7 +940,7 @@ Wombat.prototype.extractOriginalURL = function(rewrittenUrl) {
 
     if (
       url !== rwURLString &&
-      !this.startsWithOneOf(url, this.VALID_PREFIXES)
+      !this.startsWithOneOf(url, this.VALID_PREFIXES) && !this.startsWith(url, 'blob:')
     ) {
       url = this.wb_orig_scheme + url;
     }

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -984,11 +984,20 @@ Wombat.prototype.makeParser = function(maybeRewrittenURL, doc) {
     }
   }
 
+  return this._makeURLParser(originalURL, docElem);
+
+};
+
+Wombat.prototype._makeURLParser = function(url, docElem) {
+  try {
+    return new this.$wbwindow.URL(url, docElem.baseURI);
+  } catch (e) {}
+
   var p = docElem.createElement('a');
   p._no_rewrite = true;
-  p.href = originalURL;
+  p.href = url;
   return p;
-};
+}
 
 /**
  * Defines a new getter and optional setter for the property on the supplied
@@ -1367,7 +1376,7 @@ Wombat.prototype.setLoc = function(loc, originalURL) {
   loc._hostname = parser.hostname;
 
   if (parser.origin) {
-    loc._origin = parser.origin;
+    loc._origin = parser.host ? parser.origin : "null";
   } else {
     loc._origin =
       parser.protocol +
@@ -2930,8 +2939,7 @@ Wombat.prototype.overrideHistoryFunc = function(funcName) {
     var rewritten_url;
     var resolvedURL;
     if (url) {
-      var parser = historyWin.document.createElement('a');
-      parser.href = url;
+      var parser = wombat._makeURLParser(url, historyWin.document);
       resolvedURL = parser.href;
 
       rewritten_url = wombat.rewriteUrl(resolvedURL);

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3851,8 +3851,20 @@ Wombat.prototype.initDateOverride = function(timestamp) {
 
   this.$wbwindow.Date.__WB_timediff = timediff;
 
-  this.$wbwindow.Date.getTimezoneOffset = function() {
+  this.$wbwindow.Date.prototype.getTimezoneOffset = function() {
     return 0;
+  }
+
+  var orig_toString = this.$wbwindow.Date.prototype.toString;
+  this.$wbwindow.Date.prototype.toString = function() {
+    var string = orig_toString.call(this).split(" GMT")[0];
+    return string + " GMT+0000 (Coordinated Universal Time)";
+  }
+
+  var orig_toTimeString = this.$wbwindow.Date.prototype.toTimeString;
+  this.$wbwindow.Date.prototype.toTimeString = function() {
+    var string = orig_toTimeString.call(this).split(" GMT")[0];
+    return string + " GMT+0000 (Coordinated Universal Time)";
   }
 
   Object.defineProperty(this.$wbwindow.Date.prototype, 'constructor', {

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3851,6 +3851,10 @@ Wombat.prototype.initDateOverride = function(timestamp) {
 
   this.$wbwindow.Date.__WB_timediff = timediff;
 
+  this.$wbwindow.Date.getTimezoneOffset = function() {
+    return 0;
+  }
+
   Object.defineProperty(this.$wbwindow.Date.prototype, 'constructor', {
     value: this.$wbwindow.Date
   });


### PR DESCRIPTION
for wombat.js based replay:
- If loading from SW, override unregister() to prevent unregistering existing SW in the replay

reproducibility:
- timezone: override Date.getTimeZoneOffset(), Date.toString(), Date.toTimeString() for consistent replay
- referrer: set referrer to empty for top replay frame (otherwise maybe top-frame or custom based on embed), or rewrite existing referrer for nested frame
- URL parsing:  use URL for parser if available, fallback to anchor tag if not. set origin to null if no host (safari uses `://` by default)
- support `blob:` urls for replay frame, don't rewrite
