### PR TITLE
Add option to add extra ignored prefixes

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -49,6 +49,9 @@ function Wombat($wbwindow, wbinfo) {
     '{',
     '*'
   ];
+  if ('ignore_prefixes' in wbinfo) {
+    this.IGNORE_PREFIXES = this.IGNORE_PREFIXES.concat(wbinfo.ignore_prefixes);
+  }
 
   this.WB_CHECK_THIS_FUNC = '_____WB$wombat$check$this$function_____';
   this.WB_ASSIGN_FUNC = '_____WB$wombat$assign$function_____';


### PR DESCRIPTION
We add an option to extend `IGNORE_PREFIXES` with extra prefixes we may need
to ignore.

Some web archives may load additional resources (e.g. web stats or a
toolbar) in the playback page and wombat tries to rewrite these URLs as
well. We need a way to skip them.