### PR TITLE
Fix `Element.prototype.getAttribute` result for missing attributes

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -4411,6 +4411,9 @@ Wombat.prototype.initElementGetSetAttributeOverride = function() {
     this.wb_getAttribute = orig_getAttribute;
     ElementProto.getAttribute = function getAttribute(name) {
       var result = orig_getAttribute.call(this, name);
+      if (result === null) {
+        return result;
+      }
       var lowerName = name;
       if (name) {
         lowerName = name.toLowerCase();

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -714,6 +714,24 @@ for (const aTest of ElementGetSetAttribute) {
   }
 }
 
+test('Element.getAttribute: should return null for attributes that are not set', async t => {
+  const attrs = [
+    // Attributes which normally contain URLs when they exist.
+    'href',
+    'src',
+    'xlink:href',
+
+    // Custom attributes.
+    'custom-attr'
+  ];
+  const { sandbox, server } = t.context;
+  const result = await sandbox.evaluate(attrs => {
+    const div = document.createElement('div');
+    return attrs.map(attr => div.getAttribute(attr));
+  }, attrs);
+  t.deepEqual(result, attrs.map(() => null));
+});
+
 test('Node.ownerDocument: should return the document Proxy object when accessed', async t => {
   const { sandbox, server } = t.context;
   const result = await sandbox.evaluate(


### PR DESCRIPTION
`Element.prototype.getAttribute` should return `null` when the attribute
does not exist. Previously the override installed by Wombat returned an
empty string for the attributes `src`, `href` and `xlink:href` and
`null` for others.

In https://github.com/hypothesis/support/issues/157 we found a situation where this behavior difference caused (complex) JavaScript code on a proxied page to forward the user to a different URL whenever they clicked anywhere in the page. See https://github.com/hypothesis/support/issues/157#issuecomment-729231584 in particular.