### PR TITLE
Add .gitignore file for compiled test bundles

### DIFF
--- a/test/assets/.gitignore
+++ b/test/assets/.gitignore
@@ -1,0 +1,8 @@
+# Test bundles produced by `yarn build-test` and `yarn build-full-test`.
+
+autoFetchWorker.js
+testPageBundle.js
+wombat.js
+wombatDirect.js
+wombatProxyMode.js
+wombatWorkers.js


### PR DESCRIPTION
Add a `.gitignore` file to ignore the files created by `yarn build-test`
and `yarn build-full-test` so that they are not accidentally committed
and also so that code in these files can be ignored by tools which are
aware of `.gitignore` files.

In this PR I have simply listed the individual bundles in `test/assets/.gitgnore`. However I think
it would be better if generated code was put into a separate directory than the committed code
in `test/assets/` to avoid confusion. This would also enable simplifying the `.gitignore` rules.