### PR TITLE
init + fidelity improvements:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wbWombat.js
+++ b/src/wbWombat.js
@@ -2,12 +2,10 @@ import Wombat from './wombat';
 
 window._WBWombat = Wombat;
 window._WBWombatInit = function(wbinfo) {
-  if (!this._wb_wombat || !this._wb_wombat.actual) {
+  if (!this._wb_wombat) {
     var wombat = new Wombat(this, wbinfo);
-    wombat.actual = true;
     this._wb_wombat = wombat.wombatInit();
-    this._wb_wombat.actual = true;
-  } else if (!this._wb_wombat) {
-    console.warn('_wb_wombat missing!');
+  } else {
+    this._wb_wombat.init_paths(wbinfo);
   }
 };


### PR DESCRIPTION
- init: avoid double init of wombat, instead of update wbinfo via init_paths(). On iframe init, make a copy of wb_info to avoid references to same wb_info in multiple windows
- native func: add __WB_is_native_func__ field to bound functions to indicate if original is bound or not, as detection is otherwise not possible
- post request: support converting multipart/form-data post requests to get as well, add simple parsing of multipart form data
bump version to 3.1.0