### PR TITLE
Handle setting <a href="#"> correctly

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2106,7 +2106,7 @@ Wombat.prototype.rewriteSVGElem = function(elem) {
 };
 
 /**
- * Rewrites the supplied element returning T/F indicating if a rewrite occured
+ * Rewrites the supplied element returning T/F indicating if a rewrite occurred
  * @param {Element|Node} elem - The element to be rewritten
  * @return {boolean}
  */
@@ -2474,7 +2474,7 @@ Wombat.prototype.rewriteCookie = function(cookie) {
         wb_type: 'cookie'
       };
 
-      // norify of cookie setting to allow server-side tracking
+      // notify of cookie setting to allow server-side tracking
       wombat.sendTopMessage(message, true);
 
       // if no subdomain, eg. "localhost", just remove domain altogether

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1484,10 +1484,10 @@ Wombat.prototype.makeSetLocProp = function(prop, origSetter, origGetter) {
 
     var rel = false;
 
-    // Special case for href="." assignment
+    // Special case for assigning href to a relative path
     if (prop === 'href' && typeof value === 'string') {
       if (value) {
-        if (value[0] === '.') {
+        if (value[0] === '.' || value[0] === '#') {
           value = wombat.resolveRelUrl(value, this.ownerDocument);
         } else if (
           value[0] === '/' &&

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -38,6 +38,30 @@ test.after.always(async t => {
   await helper.stop();
 });
 
+test('links should not be broken by wombat', async t => {
+  const { sandbox, server } = t.context;
+  const actual = await sandbox.evaluate(
+    () => {
+      const a = document.createElement('a');
+      a.href = '/foo'; // note: browsers "magic" this property into an absolute URL on set.
+      return a.href
+    },
+  );
+  t.is(actual, 'https://tests.wombat.io/foo')
+});
+
+test('anchor links should not be broken by wombat', async t => {
+  const { sandbox, server } = t.context;
+  const actual = await sandbox.evaluate(
+    () => {
+      const a = document.createElement('a');
+      a.href = '#anchor'; // note: browsers "magic" this property into an absolute URL on set.
+      return a.href
+    },
+  );
+  t.is(actual, 'https://tests.wombat.io/#anchor')
+});
+
 test('document.title: should send the "title" message to the top frame when document.title is changed', async t => {
   const { sandbox, testPage } = t.context;
   await sandbox.evaluate(() => (document.title = 'abc'));


### PR DESCRIPTION
Updates `makeSetLocProp()` to correctly handle setting the `href` property on an `<a>` tag to a #hash.

I included a couple of tests, one that was failing before this change and one that passes either way (the later may be a duplicate, sorry if that's the case.)

FWIW, it feels like `makeSetLocProp()` is doing a bit more work than it needs to, because it calls `rewriteUrl()` at the end. I didn't try this, but I wonder if it would work to just call `rewriteUrl()` right away and not bother trying to parse `href` values at all. Since I don't feel like I have a strong understanding of the overall system, though, I decided to keep this change small and precise.
    
Fixes #51