### PR TITLE
Handle race cases when workerUrl is not of String type.

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2512,6 +2512,7 @@ Wombat.prototype.rewriteCookie = function(cookie) {
  */
 Wombat.prototype.rewriteWorker = function(workerUrl) {
   if (!workerUrl) return workerUrl;
+  workerUrl = workerUrl.toString();
   var isBlob = workerUrl.indexOf('blob:') === 0;
   var isJS = workerUrl.indexOf('javascript:') === 0;
   if (!isBlob && !isJS) {


### PR DESCRIPTION
There can be possible cases when passed `workerUrl` to `rewriteWorker` function may not be of String type and in this case further the line `workerUrl.indexOf('blob:') === 0;` would raise "TypeError: workerUrl.indexOf is not a function". So I think its better to use explicit cast to ensure we do have String type.

In my case, the workerUrl which was being passed was actually of type [`TrustedScriptURL`](https://developer.mozilla.org/en-US/docs/Web/API/TrustedScriptURL) when trying to use wombatJS on page: https://www.google.com/recaptcha/api2/demo.
![image](https://user-images.githubusercontent.com/34530901/117927581-063a4080-b318-11eb-81e7-11efc17afb12.png)

I am not sure what actually would cause to make url into TrustedScriptURL since when I looked more into this, the Google recaptcha script would normally create a new worker by passing a normal url of String type, no idea how it becomes of type TrustedScriptURL. But certainly this change would ensure we do have workerUrl of type String in all cases and not relying on actual type of passed workerUrl.