### PR TITLE
post-to-get cleanup/compatibility with pywb/cdxj-indexer/warcio.js:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",


### PR DESCRIPTION
- simplify post-to-get conversion
- handle binary data as base64 with __wb_post_data
- handle empty data as empty '__wb_post_data='
- for text/plain, attempt to parse as json, then treat as binary
bump to 3.1.6