### PR TITLE
Return undefined for storage getter for missing keys

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5761,7 +5761,7 @@ Wombat.prototype.initStorageOverride = function() {
       return {
         get: function(target, prop) {
           if (prop in target) return target[prop];
-          return target.getItem(prop);
+          return target.data.hasOwnProperty(prop) ? target.getItem(prop) : undefined;
         },
         set: function(target, prop, value) {
           if (target.hasOwnProperty(prop)) return false;


### PR DESCRIPTION
While fixing all the issues reported in #65 may require an overhaul of the custom Storage implementation, this PR addresses one of the issues in which an attribute getter for a missing key should return `undefined`, not a `null`.