### PR TITLE
storage refactor to address issues in #65

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/customStorage.js
+++ b/src/customStorage.js
@@ -50,10 +50,10 @@ export function Storage(wombat, type, initData) {
 function storageProxyHandler() {
   return {
     get: function(target, prop) {
-      if (prop === "__orig") {
-        return target;
+      if (prop === "__proto__") {
+        return target.__proto__;
       }
-      //if (prop in target) return target[prop];
+
       if (target.__proto__.hasOwnProperty(prop)) {
         var res = target[prop];
 

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -6474,7 +6474,6 @@ Wombat.prototype.wombatInit = function() {
 
   var wombat = this;
   return {
-    actual: false,
     extract_orig: this.extractOriginalURL,
     rewrite_url: this.rewriteUrl,
     watch_elem: this.watchElem,

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import FuncMap from './funcMap';
-import Storage from './customStorage';
+import { createStorage, Storage } from './customStorage';
 import WombatLocation from './wombatLocation';
 import AutoFetcher from './autoFetcher';
 import { wrapEventListener, wrapSameOriginEventListener } from './listeners';
@@ -5740,10 +5740,6 @@ Wombat.prototype.initDisableNotificationsGeoLocation = function() {
 Wombat.prototype.initStorageOverride = function() {
   this.addEventOverride('storageArea', this.$wbwindow.StorageEvent.prototype);
 
-  var local;
-  var session;
-  var pLocal = 'localStorage';
-  var pSession = 'sessionStorage';
   ThrowExceptions.yes = false;
 
   var initStorage = {};
@@ -5756,43 +5752,9 @@ Wombat.prototype.initStorageOverride = function() {
     }
   }
 
-  if (this.$wbwindow.Proxy) {
-    var storageProxyHandler = function() {
-      return {
-        get: function(target, prop) {
-          if (prop in target) return target[prop];
-          return target.data.hasOwnProperty(prop) ? target.getItem(prop) : undefined;
-        },
-        set: function(target, prop, value) {
-          if (target.hasOwnProperty(prop)) return false;
-          target.setItem(prop, value);
-          return true;
-        },
-        getOwnPropertyDescriptor: function(target, prop) {
-          return Object.getOwnPropertyDescriptor(target, prop);
-        }
-      };
-    };
-    local = new this.$wbwindow.Proxy(
-      new Storage(this, pLocal, initStorage.local),
-      storageProxyHandler()
-    );
-    session = new this.$wbwindow.Proxy(
-      new Storage(this, pSession, initStorage.session),
-      storageProxyHandler()
-    );
-  } else {
-    local = new Storage(this, pLocal, initStorage.local);
-    session = new Storage(this, pSession, initStorage.session);
-  }
+  createStorage(this, "localStorage", initStorage.local);
+  createStorage(this, "sessionStorage", initStorage.session);
 
-  this.defGetterProp(this.$wbwindow, pLocal, function localStorage() {
-    return local;
-  });
-
-  this.defGetterProp(this.$wbwindow, pSession, function sessionStorage() {
-    return session;
-  });
   // ensure localStorage instanceof Storage works
   this.$wbwindow.Storage = Storage;
   ThrowExceptions.yes = true;

--- a/test/direct-custom-storage.js
+++ b/test/direct-custom-storage.js
@@ -68,13 +68,14 @@ test('Storage - setItem: the item set should be mapped and an storage event fire
   const { sandbox, server } = t.context;
   const testResult = await sandbox.evaluate(() => {
     const storage = new Storage(window.fakeWombat, 'bogus value');
+    const DATA = Object.getOwnPropertySymbols(storage)[0];
     const key = 'a';
     const value = 'b';
     storage.setItem(key, value);
     const events = window.fakeWombat.storage_listeners.sEvents;
     const event = events[0];
     return {
-      stored: storage.data[key] === value,
+      stored: storage[DATA][key] === value,
       numEvents: events.length,
       key: event.key === key,
       newValue: event.newValue === value,
@@ -98,6 +99,7 @@ test('Storage - removeItem: the item set should be removable and an event should
   const { sandbox, server } = t.context;
   const testResult = await sandbox.evaluate(() => {
     const storage = new Storage(window.fakeWombat, 'bogus value');
+    const DATA = Object.getOwnPropertySymbols(storage)[0];
     const key = 'a';
     const value = 'b';
     storage.setItem(key, value);
@@ -105,7 +107,7 @@ test('Storage - removeItem: the item set should be removable and an event should
     const events = window.fakeWombat.storage_listeners.sEvents;
     const event = events[1];
     return {
-      stored: storage.data[key] === undefined,
+      stored: storage[DATA][key] === undefined,
       numEvents: events.length,
       key: event.key === key,
       newValue: event.newValue === null,

--- a/test/direct-custom-storage.js
+++ b/test/direct-custom-storage.js
@@ -68,14 +68,13 @@ test('Storage - setItem: the item set should be mapped and an storage event fire
   const { sandbox, server } = t.context;
   const testResult = await sandbox.evaluate(() => {
     const storage = new Storage(window.fakeWombat, 'bogus value');
-    const DATA = Object.getOwnPropertySymbols(storage)[0];
     const key = 'a';
     const value = 'b';
     storage.setItem(key, value);
     const events = window.fakeWombat.storage_listeners.sEvents;
     const event = events[0];
     return {
-      stored: storage[DATA][key] === value,
+      stored: storage[key] === value,
       numEvents: events.length,
       key: event.key === key,
       newValue: event.newValue === value,
@@ -99,7 +98,6 @@ test('Storage - removeItem: the item set should be removable and an event should
   const { sandbox, server } = t.context;
   const testResult = await sandbox.evaluate(() => {
     const storage = new Storage(window.fakeWombat, 'bogus value');
-    const DATA = Object.getOwnPropertySymbols(storage)[0];
     const key = 'a';
     const value = 'b';
     storage.setItem(key, value);
@@ -107,7 +105,7 @@ test('Storage - removeItem: the item set should be removable and an event should
     const events = window.fakeWombat.storage_listeners.sEvents;
     const event = events[1];
     return {
-      stored: storage[DATA][key] === undefined,
+      stored: storage[key] === undefined,
       numEvents: events.length,
       key: event.key === key,
       newValue: event.newValue === null,

--- a/test/direct-wombat-util-fns.js
+++ b/test/direct-wombat-util-fns.js
@@ -15,7 +15,9 @@ test.beforeEach(async t => {
   t.context.sandbox = helper.sandbox();
   t.context.testPage = helper.testPage();
   t.context.server = helper.server();
-  await helper.initWombat();
+  await t.context.sandbox.evaluate(() => {
+    window.wombat = new window.Wombat(window, window.wbinfo);
+  });
 });
 
 test.after.always(async t => {

--- a/test/overrides-storage.js
+++ b/test/overrides-storage.js
@@ -1,0 +1,260 @@
+import test from 'ava';
+import TestHelper from './helpers/testHelper';
+
+/**
+ * @type {TestHelper}
+ */
+let helper = null;
+
+test.before(async t => {
+  helper = await TestHelper.init(t);
+  await helper.initWombat();
+});
+
+test.beforeEach(async t => {
+  t.context.sandbox = helper.sandbox();
+  t.context.server = helper.server();
+  t.context.testPage = helper.testPage();
+});
+
+test.afterEach.always(async t => {
+  if (t.title.includes('SharedWorker')) {
+    await helper.fullRefresh();
+  } else {
+    await helper.ensureSandbox();
+  }
+});
+
+test.after.always(async t => {
+  await helper.stop();
+});
+
+test('Storage - creation: should throw error, direct construction not allowed', async t => {
+  const { sandbox, server } = t.context;
+  const creationPromise = sandbox.evaluate(() => {
+    new Storage();
+  });
+  await t.throwsAsync(creationPromise);
+});
+
+test('Storage - empty on init, internal values should not be exposed', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    return {...window.storage};
+  });
+
+  t.deepEqual(testResult, {});
+});
+
+test('Storage - missing getItem: absent items should return null', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    return storage.getItem('a') === null;
+  });
+  t.true(testResult);
+});
+
+test('Storage - missing dot accessor: absent items should return undefined to dot notation accessor', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    return storage.a === undefined;
+  });
+  t.true(testResult);
+});
+
+test('Storage - missing bracket accessor: absent items should return undefined to bracket notation accessor', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    return storage['a'] === undefined;
+  });
+  t.true(testResult);
+});
+
+test('Storage - getItem: the item set should be retrievable', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.setItem(key, value);
+    return storage.getItem(key) === value;
+  });
+  t.true(testResult);
+});
+
+test('Storage - dot accessor get: the item set should be retrievable with dot notation accessor', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.setItem(key, value);
+    return storage.a === value;
+  });
+  t.true(testResult);
+});
+
+test('Storage - bracket accessor get: the item set should be retrievable with bracket notation accessor', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.setItem(key, value);
+    return storage[key] === value;
+  });
+  t.true(testResult);
+});
+
+test('Storage - dot accessor set: the item set using dot notation accessor should be mapped', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.a = value;
+    return storage.getItem(key) === value;
+  });
+  t.true(testResult);
+});
+
+test('Storage - bracket accessor set: the item set using bracket notation accessor should be mapped', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage[key] = value;
+    storage.a = value;
+    return storage.getItem(key) === value;
+  });
+  t.true(testResult);
+});
+
+test('Storage - removeItem: the item set should be removable', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.setItem(key, value);
+    storage.removeItem(key);
+    return storage[key] === undefined;
+  });
+  t.true(testResult);
+});
+
+test('Storage - clear: should clear all stored items', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.setItem(key, value);
+    storage.clear();
+    return Object.keys(storage);
+  });
+  t.deepEqual(testResult, []);
+
+
+});
+
+test('Storage - key: should return the correct key given the keys index', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key1 = 'a1';
+    const key2 = 'a2';
+    const value1 = 'b1';
+    const value2 = 'b2';
+    storage.setItem(key1, value1);
+    storage.setItem(key2, value2);
+    return (
+      storage.key(0) === key1 &&
+      storage.key(1) === key2 &&
+      storage.key(2) === null
+    );
+  });
+  t.true(testResult);
+});
+
+test('Storage - keys: object keys should contain stored item key', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.setItem(key, value);
+    return Object.keys(storage).includes(key);
+  });
+  t.true(testResult);
+});
+
+test('Storage - property: object own property name should contain stored item key', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    const key = 'a';
+    const value = 'b';
+    storage.setItem(key, value);
+    return Object.getOwnPropertyNames(storage).includes(key);
+  });
+  t.true(testResult);
+});
+
+test('Storage - valueOf: should return the correct value', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = sessionStorage;
+    return storage.valueOf() === storage;
+  });
+  t.true(testResult);
+});
+
+test('Storage - toString: should return the correct value', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = sessionStorage;
+    return storage.toString() === "[object Storage]";
+  });
+  t.true(testResult);
+});
+
+
+test('Storage - length: should return the correct value', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = sessionStorage;
+    const key1 = 'a1';
+    const key2 = 'a2';
+    const value1 = 'b1';
+    const value2 = 'b2';
+    storage.setItem(key1, value1);
+    storage.setItem(key2, value2);
+    return storage.length;
+  });
+  t.is(testResult, 2);
+});
+
+test('Storage - assorted length: should return the correct length of various setters', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    const storage = localStorage;
+    storage.clear();
+    const key1 = 'a1';
+    const key2 = 'a2';
+    const key3 = 'a3';
+    const value1 = 'b1';
+    const value2 = 'b2';
+    const value3 = 'b3';
+    storage.setItem(key1, value1);
+    storage[key2] = value2;
+    storage.a3 = value3;
+    return storage.length;
+  });
+  t.is(testResult, 3);
+});
+

--- a/test/overrides-storage.js
+++ b/test/overrides-storage.js
@@ -258,3 +258,12 @@ test('Storage - assorted length: should return the correct length of various set
   t.is(testResult, 3);
 });
 
+test('Storage - getPrototypeOf() and __proto__ equivalence', async t => {
+  const { sandbox, server } = t.context;
+  const testResult = await sandbox.evaluate(() => {
+    return Object.getPrototypeOf(localStorage) === Object.getPrototypeOf(sessionStorage) &&
+           Object.getPrototypeOf(localStorage) === localStorage.__proto__ &&
+           Object.getPrototypeOf(localStorage) === Storage.prototype;
+  });
+  t.is(testResult, true);
+});

--- a/test/setup-initialization.js
+++ b/test/setup-initialization.js
@@ -106,7 +106,6 @@ test.serial(
     const result = await sandbox.evaluate(() => {
       window._WBWombatInit(window.wbinfo);
       return {
-        actual: window._wb_wombat.actual,
         extract_orig: typeof window._wb_wombat.extract_orig,
         rewrite_url: typeof window._wb_wombat.rewrite_url,
         watch_elem: typeof window._wb_wombat.watch_elem,
@@ -118,7 +117,6 @@ test.serial(
     t.deepEqual(
       result,
       {
-        actual: true,
         extract_orig: 'function',
         rewrite_url: 'function',
         watch_elem: 'function',


### PR DESCRIPTION
- use Symbols instead of direct properties to avoid custom proxied objects showing up in getOwnPropertyNames(), (though still show up in getOwnPropertySymbols())
- proxy override fixes: add ownKeys() override to fix Object.keys() only listing objects in storage
- ensure internal properties are not accessible/visible directly -- only visible through getOwnPropertySymbols() and getOwnPropertyDescriptors() which are less likely to be used
- add toString() override
- tests: add override storage tests with proxy, incorporating most of tests from #66 but with proxy object applied