### PR TITLE
Location Assignment Check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5125,7 +5125,9 @@ Wombat.prototype.initProtoPmOrigin = function(win) {
 
   win.__WB_check_loc = function(loc, args) {
     if (loc instanceof Location || loc instanceof WombatLocation) {
-      // check if the location is actually a local param
+      // args, if provided, should be the 'arguments' from calling function
+      // check if the location is actually a locally passed in argument,
+      // if so, don't assign to global location
       if (args) {
         for (var i = 0; i < args.length; i++) {
           if (loc === args[i]) {

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5123,8 +5123,16 @@ Wombat.prototype.initProtoPmOrigin = function(win) {
     });
   } catch (e) {}
 
-  win.__WB_check_loc = function(loc) {
+  win.__WB_check_loc = function(loc, args) {
     if (loc instanceof Location || loc instanceof WombatLocation) {
+      // check if the location is actually a local param
+      if (args) {
+        for (var i = 0; i < args.length; i++) {
+          if (loc === args[i]) {
+            return {};
+          }
+        }
+      }
       return this.WB_wombat_location;
     } else {
       return {};

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -278,4 +278,3 @@ test('browser history control: should send the "replace-url" msg to the top fram
     'the "replace-url" message was not sent to the top frame on history.pushState usage'
   );
 });
-

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -151,7 +151,7 @@ test('WombatLocation should not navigate when assigning to local object', async 
   });
   t.is(
     result,
-    `https://tests.wombat.io/it`,
+    'https://tests.wombat.io/it',
     'the page navigated away and did not return a URL'
   );
 });

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -142,12 +142,14 @@ test('WombatLocation: should have a Symbol.toStringTag value of "Location"', asy
 test('WombatLocation should not navigate when assigning to local object', async t => {
   const { sandbox, server } = t.context;
   const result = await sandbox.evaluate(() => {
+    let location = window.WB_wombat_location;
+
     function navTest(location) {
-      location = ((self.__WB_check_loc && self.__WB_check_loc(location)) || {}).href = location.protocol + '//' + location.hostname + '/it';
+      location = ((self.__WB_check_loc && self.__WB_check_loc(location, arguments)) || {}).href = location.protocol + '//' + location.hostname + '/it';
       return location;
     }
 
-    return navTest(window.WB_wombat_location);
+    return navTest(location);
   });
   t.is(
     result,

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -139,6 +139,23 @@ test('WombatLocation: should have a Symbol.toStringTag value of "Location"', asy
   );
 });
 
+test('WombatLocation should not navigate when assigning to local object', async t => {
+  const { sandbox, server } = t.context;
+  const result = await sandbox.evaluate(() => {
+    function navTest(location) {
+      location = ((self.__WB_check_loc && self.__WB_check_loc(location)) || {}).href = location.protocol + '//' + location.hostname + '/it';
+      return location;
+    }
+
+    return navTest(window.WB_wombat_location);
+  });
+  t.is(
+    result,
+    `https://tests.wombat.io/it`,
+    'the page navigated away and did not return a URL'
+  );
+});
+
 test('WombatLocation browser navigation control: should rewrite Location.replace usage', async t => {
   const { sandbox, server } = t.context;
   const [navigationResponse] = await Promise.all([
@@ -259,3 +276,4 @@ test('browser history control: should send the "replace-url" msg to the top fram
     'the "replace-url" message was not sent to the top frame on history.pushState usage'
   );
 });
+


### PR DESCRIPTION
Pass in `arguments` to `WB_check_loc` to also check if location is actually a local argument.
Fixes incorrect location override where location is actually a local object, as in webrecorder/pywb#684