### PR TITLE
Force rewritten eval() to use global scope when original is in global scope.

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -6217,6 +6217,8 @@ Wombat.prototype.initEvalOverride = function() {
     };
   };
 
+  var wombat = this;
+
   var runEval = function runEval(func) {
     var obj = this;
 
@@ -6242,12 +6244,14 @@ Wombat.prototype.initEvalOverride = function() {
     if (obj && obj.eval && obj.eval !== eval) {
       return {
         eval: function() {
-          return obj.eval.__WB_orig_apply(obj, [].slice.call(arguments, 1));
+          // should have at least 2 arguments as 2 are injected
+          return obj.eval.__WB_orig_apply(obj, [].slice.call(arguments, 2));
         }
       };
     } else {
       return {
-        eval: function(isGlobal, arg) {
+        eval: function(thisObj, isGlobal, arg) {
+          isGlobal = isGlobal && thisObj === wombat.proxyToObj(wombat.$wbwindow);
           return rewriteEvalArg(func, arg, isGlobal);
         }
       };

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -6250,9 +6250,16 @@ Wombat.prototype.initEvalOverride = function() {
       };
     } else {
       return {
-        eval: function(thisObj, isGlobal, arg) {
-          isGlobal = isGlobal && thisObj === wombat.proxyToObj(wombat.$wbwindow);
-          return rewriteEvalArg(func, arg, isGlobal);
+        eval: function(thisObj, args, evalparam) {
+          // ensure this === window
+          var isGlobal = (thisObj === wombat.proxyToObj(wombat.$wbwindow));
+          // wrap in try/catch in the off chance case we're in strict mode, and then treat as non-global
+          try {
+            isGlobal = isGlobal && !args.callee.caller;
+          } catch (e) {
+            isGlobal = false;
+          }
+          return rewriteEvalArg(func, evalparam, isGlobal);
         }
       };
     }


### PR DESCRIPTION
The eval() rewriting can sometimes result in the following scenario:
```js
eval('function test() {}');
...
test();
```

is rewritten to (simplified) effectively:
```js
(function evalwrapper(x) { eval(rewrite(x)); })('function test() {}')
...
test(); <- test not defined, no longer evaluated in global scope.
```

The rewriting is done in this way to keep the eval() in this same local scope, but if the eval() is actually in the global scope, ideally, it should be kept there!

Fortunately, it seems that there is a mostly reliable way to detect a function in global scope by checking if `arguments.caller.callee` is null, eg:

```js
function isGlobalScope() { return !arguments.callee.caller; }

console.log(isGlobalScope()); // global scope, prints 'true'

console.log((function() { return isGlobalScope(); })());  // in function declaration, prints 'false'

console.log((() => isGlobalScope())()); // in arrow function, prints 'false'
```

The above seems to work in Chrome and Firefox. In Safari 14.x, the last one also prints 'true', so there is at least one false positive. However, this seems to be fixed in Safari 15.x.

As an additional sanity checked, the `this` can also be checked to ensure that it matches the current window (as an additional guard for arrow function false positive).

Also fortunately, the eval() automatically evaluates in the global scope if eval is called indirectly after assignment.
This allows for this kind of setup:

```js
function wrappedEval(x, isGlobal) {
  var eg = eval;
   return isGlobal ? eg(x) : eval(x);
}
```

This PR implements this functionality, along with change in server-side rewriting which rewrites:
`eval(...` -> `.eval(this,  !arguments.callee.caller, ...`.

I *think* this should work w/o breaking anything, but want to leave this up for any feedback..

(Sample site fixed by this: http://svlavra.dn.ua/)