### PR TITLE
Keep local reference to "Window"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -13,9 +13,6 @@ import {
 import { postToGetUrl } from 'warcio/src/utils.js';
 
 
-var WBWindow = Window;
-
-
 /**
  * @param {Window} $wbwindow
  * @param {Object} wbinfo
@@ -28,6 +25,7 @@ function Wombat($wbwindow, wbinfo) {
 
   /** @type {Window} */
   this.$wbwindow = $wbwindow;
+  this.WBWindow = Window;
 
   /** @type {string} */
   this.HTTP_PREFIX = 'http://';
@@ -1389,7 +1387,7 @@ Wombat.prototype.defaultProxyGet = function(obj, prop, ownProps, fnCache) {
     }
     return cachedFN.boundFn;
   } else if (type === 'object' && retVal && retVal._WB_wombat_obj_proxy) {
-    if (retVal instanceof WBWindow) {
+    if (retVal instanceof this.WBWindow) {
       this.initNewWindowWombat(retVal);
     }
     return retVal._WB_wombat_obj_proxy;
@@ -1577,7 +1575,7 @@ Wombat.prototype.domConstructorErrorChecker = function(
 ) {
   var needArgs = typeof numRequiredArgs === 'number' ? numRequiredArgs : 1;
   var errorMsg;
-  if (thisObj instanceof WBWindow) {
+  if (thisObj instanceof this.WBWindow) {
     errorMsg =
       'Failed to construct \'' +
       what +

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -12,6 +12,10 @@ import {
 
 import { postToGetUrl } from 'warcio/src/utils.js';
 
+
+var WBWindow = Window;
+
+
 /**
  * @param {Window} $wbwindow
  * @param {Object} wbinfo
@@ -1385,7 +1389,7 @@ Wombat.prototype.defaultProxyGet = function(obj, prop, ownProps, fnCache) {
     }
     return cachedFN.boundFn;
   } else if (type === 'object' && retVal && retVal._WB_wombat_obj_proxy) {
-    if (retVal instanceof Window) {
+    if (retVal instanceof WBWindow) {
       this.initNewWindowWombat(retVal);
     }
     return retVal._WB_wombat_obj_proxy;
@@ -1573,7 +1577,7 @@ Wombat.prototype.domConstructorErrorChecker = function(
 ) {
   var needArgs = typeof numRequiredArgs === 'number' ? numRequiredArgs : 1;
   var errorMsg;
-  if (thisObj instanceof Window) {
+  if (thisObj instanceof WBWindow) {
     errorMsg =
       'Failed to construct \'' +
       what +


### PR DESCRIPTION
In response to an example where a page overrides 'Window', keep a reference to global 'Window' object (for instanceof)

Fixes #95