### PR TITLE
opt: store origHost, origHostname, origProtocol and replayTopHost, re…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",


### PR DESCRIPTION
…playTopProtocol vars in wombat object, to be used in rewriteUrl to avoid dependency on window.

fixes issue if rewriteUrl() is called through a path where window has already been closed and location no longer available. bump to 3.3.11

Fixes replay on https://issuu.com/ pages.