### PR TITLE
Location Fixes

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1508,7 +1508,13 @@ Wombat.prototype.makeSetLocProp = function(prop, origSetter, origGetter) {
 
     // Special case for assigning href to a relative path
     if (prop === 'href' && typeof value === 'string') {
-      if (value) {
+      if (value && this._parser instanceof URL) {
+        try {
+          value = new URL(value, this._parser).href;
+        } catch (e) {
+          console.warn('Error resolving URL', e);
+        }
+      } else if (value) {
         if (value[0] === '.' || value[0] === '#') {
           value = wombat.resolveRelUrl(value, this.ownerDocument);
         } else if (value[0] === '/') {

--- a/src/wombatLocation.js
+++ b/src/wombatLocation.js
@@ -87,7 +87,8 @@ WombatLocation.prototype.assign = function assign(url) {
  * @return {*}
  */
 WombatLocation.prototype.reload = function reload(forcedReload) {
-  return this._orig_loc.reload(forcedReload || false);
+  //return this._orig_loc.reload(forcedReload || false);
+  return;
 };
 
 /**

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -188,19 +188,19 @@ test('WombatLocation browser navigation control: should rewrite Location.assign 
   );
 });
 
-test('WombatLocation browser navigation control: should reload the page via Location.reload usage', async t => {
+test('WombatLocation browser navigation control: should *not* reload the page via WombatLocation.reload usage', async t => {
   const { sandbox, server } = t.context;
-  const [originalLoc, navigationResponse] = await Promise.all([
+  const [originalLoc, currentLoc] = await Promise.all([
     sandbox.evaluate(() => window.location.href),
-    sandbox.waitForNavigation(),
     sandbox.evaluate(() => {
       window.WB_wombat_location.reload();
+      return window.location.href;
     })
   ]);
   t.is(
-    navigationResponse.url(),
     originalLoc,
-    'using WB_wombat_location.reload did not reload the page'
+    currentLoc
+    'using WB_wombat_location.reload() did not stay on the page'
   );
 });
 

--- a/test/overrides-browser.js
+++ b/test/overrides-browser.js
@@ -199,7 +199,7 @@ test('WombatLocation browser navigation control: should *not* reload the page vi
   ]);
   t.is(
     originalLoc,
-    currentLoc
+    currentLoc,
     'using WB_wombat_location.reload() did not stay on the page'
   );
 });


### PR DESCRIPTION
- fix rewriting of location urls (eg. `window.location.href = 'path/index.html'`), just use URL class for resolving relative URLs
- make location.reload() a nop - no particular reason to allow reloading as state does not persist across reloads and can only lead to infinite loops.