### PR TITLE
Proxy for .style to rewrite property assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.3.14",
+  "version": "3.4.0",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/fs-extra": "^8.0.0",
     "ava": "^2.3.0",
     "chokidar": "^3.0.2",
-    "chrome-launcher": "^0.13.4",
+    "chrome-launcher": "^0.15.1",
     "chrome-remote-interface-extra": "^1.1.1",
     "eslint": "^6.2.2",
     "eslint-config-prettier": "^6.1.0",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3274,7 +3274,7 @@ Wombat.prototype.overrideStyleProxy = function(overrideProps) {
       get(target, prop, receiver) {
         var value = target[prop];
 
-        if (typeof value === "function" && (prop === "setProperty" || wombat.isNativeFunction(value))) {
+        if (typeof value === 'function' && (prop === 'setProperty' || wombat.isNativeFunction(value))) {
           if (!fnCache[prop]) {
             fnCache[prop] = value.bind(style);
           }

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3267,7 +3267,12 @@ Wombat.prototype.overrideStyleProxy = function(overrideProps) {
 
         target[prop] = value;
         return true;
+      },
+
+      get(target, prop, receiver) {
+        return target[prop];
       }
+
     });
 
     return proxy;

--- a/test/helpers/initChrome.js
+++ b/test/helpers/initChrome.js
@@ -41,7 +41,7 @@ async function initChrome() {
   const chrome = await launch({
     chromeFlags: chromeArgs
   });
-  const client = await CRIExtra({ host: 'localhost', port: chrome.port });
+  const client = await CRIExtra({ host: '127.0.0.1', port: chrome.port });
   const browser = await Browser.create(client, {
     ignoreHTTPSErrors: true,
     additionalDomains: { workers: true },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,17 +1138,15 @@ chokidar@^3.0.2:
   optionalDependencies:
     fsevents "^2.0.6"
 
-chrome-launcher@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.13.4.tgz#4c7d81333c98282899c4e38256da23e00ed32f73"
-  integrity sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==
+chrome-launcher@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.15.1.tgz#0a0208037063641e2b3613b7e42b0fcb3fa2d399"
+  integrity sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==
   dependencies:
     "@types/node" "*"
-    escape-string-regexp "^1.0.5"
+    escape-string-regexp "^4.0.0"
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
-    mkdirp "^0.5.3"
-    rimraf "^3.0.2"
 
 chrome-remote-interface-extra@^1.1.1:
   version "1.1.1"
@@ -1608,6 +1606,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-config-prettier@^6.1.0:
   version "6.1.0"
@@ -2912,24 +2915,12 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
 mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-mkdirp@^0.5.3:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
-  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
-  dependencies:
-    minimist "^1.2.5"
 
 ms@2.0.0:
   version "2.0.0"
@@ -3612,13 +3603,6 @@ rimraf@2.6.3, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
- Wrap HTMLElement.style in proxy to rewrite direct property assignment, eg. `div.style["background-image"] = url("https://example.com/")` (addresses an issue in webrecorder/pywb#771
- Add function check in proxy, return de-proxied object for native functions and overridden setProperty
- bump to 3.4.0!