### PR TITLE
cookie presets add set path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -4344,7 +4344,7 @@ Wombat.prototype.initCookiePreset = function() {
   if (this.wb_info.presetCookie) {
     var splitCookies = this.wb_info.presetCookie.split(';');
     for (var i = 0; i < splitCookies.length; i++) {
-      this.$wbwindow.document.cookie = splitCookies[i].trim() + "; Path=" + this.rewriteUrl("./", true);
+      this.$wbwindow.document.cookie = splitCookies[i].trim() + '; Path=' + this.rewriteUrl('./', true);
     }
   }
 };

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -4344,7 +4344,7 @@ Wombat.prototype.initCookiePreset = function() {
   if (this.wb_info.presetCookie) {
     var splitCookies = this.wb_info.presetCookie.split(';');
     for (var i = 0; i < splitCookies.length; i++) {
-      this.$wbwindow.document.cookie = splitCookies[i].trim();
+      this.$wbwindow.document.cookie = splitCookies[i].trim() + "; Path=" + this.rewriteUrl("./", true);
     }
   }
 };


### PR DESCRIPTION
Add explicit path to preset cookies, as this apparently ensures that they appear before newly added cookies in `document.cookie`.