### PR TITLE
Nav set cap handle config override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -79,7 +79,6 @@ export function wrapEventListener(origListener, obj, wombat) {
       ne._srcElement = event.srcElement;
       ne._currentTarget = event.currentTarget;
       ne._eventPhase = event.eventPhase;
-      ne._composedPath = event.composedPath;
     } else {
       ne = event;
     }

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -79,7 +79,7 @@ export function wrapEventListener(origListener, obj, wombat) {
       ne._srcElement = event.srcElement;
       ne._currentTarget = event.currentTarget;
       ne._eventPhase = event.eventPhase;
-      ne._path = event.path;
+      ne._composedPath = event.composedPath;
     } else {
       ne = event;
     }

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5747,7 +5747,9 @@ Wombat.prototype.initBeaconOverride = function() {
 };
 
 Wombat.prototype.initMiscNavigatorOverrides = function() {
-  this.$wbwindow.navigator.mediaDevices.setCaptureHandleConfig = function() {};
+  if (this.$wbwindow.navigator.mediaDevices) {
+    this.$wbwindow.navigator.mediaDevices.setCaptureHandleConfig = function() {};
+  }
 };
 
 

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5746,6 +5746,11 @@ Wombat.prototype.initBeaconOverride = function() {
   };
 };
 
+Wombat.prototype.initMiscNavigatorOverrides = function() {
+  this.$wbwindow.navigator.mediaDevices.setCaptureHandleConfig = function() {};
+};
+
+
 /**
  * Applies an override to the constructor of the PresentationRequest interface object
  * in order to rewrite its URL(s) arguments
@@ -6594,6 +6599,9 @@ Wombat.prototype.wombatInit = function() {
 
   // sendBeacon override
   this.initBeaconOverride();
+
+  // additional navigator. overrides
+  this.initMiscNavigatorOverrides();
 
   // other overrides
   // proxy mode: only using these overrides

--- a/test/helpers/testedValues.js
+++ b/test/helpers/testedValues.js
@@ -385,7 +385,6 @@ exports.TestedPropertyDescriptorUpdates = [
       'srcElement',
       'currentTarget',
       'eventPhase',
-      'composedPath',
       'source'
     ],
     expectedInterface: {

--- a/test/helpers/testedValues.js
+++ b/test/helpers/testedValues.js
@@ -385,7 +385,7 @@ exports.TestedPropertyDescriptorUpdates = [
       'srcElement',
       'currentTarget',
       'eventPhase',
-      'path',
+      'composedPath',
       'source'
     ],
     expectedInterface: {


### PR DESCRIPTION
Addresses webrecorder/archiveweb.page#138
Tests: remove overriding MessageEvent.path, as property has been removed from Chrome (and wasn't being used anyway)