### PR TITLE
Unrewrite style attrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3112,9 +3112,19 @@ Wombat.prototype.overrideStyleAttr = function(obj, attr, propName) {
 
   var getter = orig_getter;
 
+  var extractUrl = function (_, p1, p2, p3, p4) {
+    return p1 + (p2 || '') + wombat.extractOriginalURL(p3) + p4;
+  };
+
+  var EXTRACT_URL_RX = /(url\()(['"])?(.*?)(\2\))/;
+
   if (!orig_getter) {
     getter = function overrideStyleAttrGetter() {
-      return this.getPropertyValue(propName);
+      var res = this.getPropertyValue(propName);
+      if (res && res.startsWith('url(')) {
+        res = res.replace(EXTRACT_URL_RX, extractUrl);
+      }
+      return res;
     };
   }
 
@@ -3218,7 +3228,7 @@ Wombat.prototype.overrideHtmlAssign = function(elem, prop, rewriteGetter) {
 
 
 /**
- * Override .dataset element on element and wraps in a proxy that unrewrites URLs
+ * Override .dataset attribute on element and wraps in a proxy that unrewrites URLs
  */
 Wombat.prototype.overrideDataSet = function() {
   var obj = this.$wbwindow.HTMLElement.prototype;
@@ -3250,7 +3260,7 @@ Wombat.prototype.overrideDataSet = function() {
 
 
 /**
- * Override .dataset element on element and wraps in a proxy that unrewrites URLs
+ * Override .style attribute on element and wraps in a proxy that unrewrites URLs
  */
 Wombat.prototype.overrideStyleProxy = function(overrideProps) {
   var obj = this.$wbwindow.HTMLElement.prototype;

--- a/test/overrides-css.js
+++ b/test/overrides-css.js
@@ -60,14 +60,14 @@ for (const attrToProp of CSS.styleAttrs.attrs) {
 }
 
 for (const attrToProp of CSS.styleAttrs.attrs) {
-  test(`style.setProperty("${attrToProp.attr}", "value"): value should be rewritten`, async t => {
+  test(`style.setProperty("${attrToProp.attr}", "value"): value should NOT be rewritten`, async t => {
     const { sandbox } = t.context;
     const result = await sandbox.evaluate(
       CSS.styleAttrs.testFNSetProp,
       attrToProp.attr,
       attrToProp.unrw
     );
-    t.notDeepEqual(result, attrToProp.unrw);
+    t.deepEqual(result, attrToProp.unrw);
   });
   if (attrToProp.attr !== attrToProp.propName) {
     test(`style.setProperty("${attrToProp.propName}", "value"): value should be rewritten`, async t => {

--- a/test/overrides-css.js
+++ b/test/overrides-css.js
@@ -67,7 +67,7 @@ for (const attrToProp of CSS.styleAttrs.attrs) {
       attrToProp.attr,
       attrToProp.unrw
     );
-    if (['backgroundImage', 'cursor', 'background', 'pointer'].includes(attrToProp.attr)) {
+    if (['cursor', 'background'].includes(attrToProp.attr)) {
       t.deepEqual(result, attrToProp.unrw);
     } else {
       t.notDeepEqual(result, attrToProp.unrw);

--- a/test/overrides-css.js
+++ b/test/overrides-css.js
@@ -60,14 +60,18 @@ for (const attrToProp of CSS.styleAttrs.attrs) {
 }
 
 for (const attrToProp of CSS.styleAttrs.attrs) {
-  test(`style.setProperty("${attrToProp.attr}", "value"): value should NOT be rewritten`, async t => {
+  test(`style.setProperty("${attrToProp.attr}", "value"): value should be rewritten only if not url()`, async t => {
     const { sandbox } = t.context;
     const result = await sandbox.evaluate(
       CSS.styleAttrs.testFNSetProp,
       attrToProp.attr,
       attrToProp.unrw
     );
-    t.deepEqual(result, attrToProp.unrw);
+    if (attrToProp === "backgroundImage" || attrToProp === "cursor") {
+      t.deepEqual(result, attrToProp.unrw);
+    } else {
+      t.notDeepEqual(result, attrToProp.unrw);
+    }
   });
   if (attrToProp.attr !== attrToProp.propName) {
     test(`style.setProperty("${attrToProp.propName}", "value"): value should be rewritten`, async t => {

--- a/test/overrides-css.js
+++ b/test/overrides-css.js
@@ -67,7 +67,7 @@ for (const attrToProp of CSS.styleAttrs.attrs) {
       attrToProp.attr,
       attrToProp.unrw
     );
-    if (attrToProp === "backgroundImage" || attrToProp === "cursor") {
+    if (['backgroundImage', 'cursor', 'background', 'pointer'].includes(attrToProp.attr)) {
       t.deepEqual(result, attrToProp.unrw);
     } else {
       t.notDeepEqual(result, attrToProp.unrw);


### PR DESCRIPTION
Ensure `style.*` attributes that contain URLs are unrewritten on access, part of fix for webrecorder/wabac.js#108
bump to 3.4.6