### PR TITLE
Rewrite document.write / srcdoc assign with remote blob fetch when in service-worker mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3216,7 +3216,12 @@ Wombat.prototype.overrideHtmlAssignSrcDoc = function(elem, prop) {
   var setter = function overrideSetter(orig) {
     this.__wb_srcdoc = orig;
 
-    this.src = wombat.srcDocUrl(wombat.rewriteHtml(orig));
+    if (wombat.wb_info.isSW) {
+      this.src = wombat.srcDocUrl(wombat.rewriteHtml(orig));
+      return orig;
+    } else {
+      return wombat.rewriteHTMLAssign(this, orig_setter, orig);
+    }
   };
 
   var getter = function overrideGetter() {

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -4921,7 +4921,7 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
   function docWrite(fnThis, originalFn, string) {
     var win = wombat.$wbwindow;
 
-    if (isSWLoad()) {
+    if (fnThis.readyState === 'complete' && isSWLoad()) {
       wombat._writeBuff += string;
       return;
     }


### PR DESCRIPTION
Due to several issues in Chrome, in particular:
https://bugs.chromium.org/p/chromium/issues/detail?id=880768
https://bugs.chromium.org/p/chromium/issues/detail?id=1102209

an iframe loses its service worker after document.write is called in the iframe. Same for about:blank or srcdoc: iframe.
As a work-around, prevent document.write() calls from being made, and instead store the written text, create blob, and load via service-worker `/blob:<blob id>` response, thereby allowing the iframe to still be controlled by the service worker.
Also override srcdoc: assignment and convert to blob in the same way