### PR TITLE
import relative rewrite fix: change __wb_rewrite_import__(url) -> __w…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5368,8 +5368,12 @@ Wombat.prototype.initCheckThisFunc = function(win) {
 
 Wombat.prototype.initImportWrapperFunc = function(win) {
   var wombat = this;
-  win.____wb_rewrite_import__ = function(url) {
-    return import(/*webpackIgnore: true*/ wombat.rewriteUrl(url));
+  win.____wb_rewrite_import__ = function(base, url) {
+    // if base provided (import.meta.url), use that as base for imports
+    if (base) {
+      url = new URL(url, base).href;
+    }
+    return import(/*webpackIgnore: true*/ wombat.rewriteUrl(url, false, 'esm_'));
   };
 };
 

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5369,7 +5369,7 @@ Wombat.prototype.initCheckThisFunc = function(win) {
 Wombat.prototype.initImportWrapperFunc = function(win) {
   var wombat = this;
   win.____wb_rewrite_import__ = function(base, url) {
-    // if base provided (import.meta.url), use that as base for imports
+    // if base provided (set to import.meta.url), use that as base for imports
     if (base) {
       url = new URL(url, base).href;
     }


### PR DESCRIPTION
…b_rewrite_import__(base, url)

where base is either empty or the 'import.meta.url' (if used in a module) if base is provided, resolve url with base to ensure relative urls resolve to correct module-relative url bump to 3.5.0
part of fix for issue raised in #116