### PR TITLE
location prop set: skip update if new value == old, 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombatLocation.js
+++ b/src/wombatLocation.js
@@ -31,7 +31,9 @@ export default function WombatLocation(orig_loc, wombat) {
     orig_setter: {
       enumerable: false,
       value: function(prop, value) {
-        this._orig_loc[prop] = value;
+        if (this._orig_loc[prop] != value) {
+          this._orig_loc[prop] = value;
+        }
       }
     }
   });


### PR DESCRIPTION
sometimes results in spurious refresh, and can err on side of skipping (ex: https://neural.love/ai-art-generator/1ede9fe2-9a61-6fe8-b093-25bfc69c7b3b/biopunk-factory)
Part of fix for webrecorder/archiveweb.page#156