### PR TITLE
Doc Write Buffer on Load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2143,7 +2143,7 @@ Wombat.prototype.rewriteScript = function(elem) {
   var text = elem.textContent.trim();
   if (this.skipWrapScriptTextBasedOnText(text)) return false;
   elem.textContent = this.wrapScriptTextJsProxy(text);
-  if (this.wb_info.hasFlushWrite && elem.textContent.trim().length) {
+  if (this.wb_info.injectDocClose && elem.textContent.trim().length) {
     elem.textContent += ';document.close();';
   }
   return true;
@@ -4935,7 +4935,7 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
   function docWrite(fnThis, originalFn, string) {
     var win = wombat.$wbwindow;
 
-    if (isSWLoad() || (document.readyState === 'loading' && wombat.wb_info.hasFlushWrite)) {
+    if (isSWLoad() || (document.readyState === 'loading' && wombat.wb_info.injectDocClose)) {
       wombat._writeBuff += string;
       return;
     }

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2428,11 +2428,21 @@ Wombat.prototype.rewriteHtml = function(string, checkEndTag) {
         template.content.children && template.content.children[0];
       if (first_elem) {
         var end_tag = '</' + first_elem.tagName.toLowerCase() + '>';
+        // check if new_html has an extra ending tag while original did not
+        // eg. <div>... rewritten to </div>, then we strip out the ending tag
         if (
           this.endsWith(new_html, end_tag) &&
           !this.endsWith(rwString.toLowerCase(), end_tag)
         ) {
           new_html = new_html.substring(0, new_html.length - end_tag.length);
+        // similarly, check if original had extra ending tags that rewritten did not
+        // eg. <a>...</a></div> rewritten to <a>...</a>, then we add the remaining </div>
+        // currently only works with different tags
+        } else if (new_html.trimEnd().endsWith(end_tag) && !rwString.trimEnd().endsWith(end_tag)) {
+          var lastInx = rwString.lastIndexOf(end_tag);
+          if (lastInx > 0) {
+            new_html += rwString.slice(lastInx + end_tag.length);
+          }
         }
       } else if (rwString[0] !== '<' || rwString[rwString.length - 1] !== '>') {
         this.write_buff += rwString;

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5001,9 +5001,6 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       wombat._writeBuff = '';
       return;
     }
-    if (document.readyState === 'loading') {
-      return;
-    }
     var thisObj = wombat.proxyToObj(this);
     wombat.initNewWindowWombat(thisObj.defaultView);
     if (originalClose.__WB_orig_apply) {

--- a/test/assets/sandboxDirect.html
+++ b/test/assets/sandboxDirect.html
@@ -32,6 +32,7 @@
       window.wbinfo.wombat_opts = {};
       window.wbinfo.state = '';
       window.wbinfo.metadata = {};
+      window.wbinfo.injectDocClose = true;
     </script>
   </head>
   <body>

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -274,6 +274,33 @@ test('document.write: should perform rewriting when "write" is called with an ar
   );
 });
 
+test('document.write: should perform rewriting with multiple write calls, each including partial html snippet', async t => {
+  const { sandbox, server } = t.context;
+  const expectedRW = '<html><head></head><body><div><div><a href="http://localhost:3030/live/20180803160549mp_/http://javaScript.com/script.js">Link 1</a></div>Link 2</div></body></html>';
+  const result = await sandbox.evaluate(() => {
+    document.write('</div><div><div><a href="http://javaScript.com/script.js">Link 1</a>');
+    document.write('</div');
+    document.write('<a href="https://example.com/">Link 2</a></div></div>');
+    document.close();
+    document.documentElement._no_rewrite = true;
+    return {
+      doctype: document.doctype != null,
+      html: document.documentElement.outerHTML
+    };
+  });
+  t.deepEqual(
+    result,
+    {
+      doctype: false,
+      html: expectedRW
+    },
+    'wombat is not rewriting elements when document.write is used with full strings of html with <body>'
+  );
+});
+
+
+
+
 test('document.writeln: should not perform rewriting when "writeln" is called with no arguments', async t => {
   const { sandbox, testPage } = t.context;
   await sandbox.evaluate(() => {


### PR DESCRIPTION
When overriding document.write() while page is loading (in inline scripts), buffer all write() calls within the script tag, and rewrite at the end. Allows for more accurate rewriting of partial HTML split over multiple write calls, eg.

```
<script>
document.write(`<div><a href="./some/link.html">`);
document.write(`Link</a>`);
document.write(`</div>`);
</script>
```

However, for this to work, a `document.close()` call must be injected into the script, so it becomes

```
<script>
document.write(`<div><a href="./some/link.html">`);
document.write(`Link</a>`);
document.write(`</div>`);
document.close();
</script>
```

The document.close() injection must happen server-side, so this is only enabled if `wombat.injectDocWrite` flag is set, otherwise per-call rewriting is used.

Also added improvements to try to detect partial tags that are removed if doing per-call rewriting

Fixes issue in #123 

