### PR TITLE
Resolve Relative URL Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -928,16 +928,8 @@ Wombat.prototype.getFinalUrl = function(useRel, mod, url) {
 Wombat.prototype.resolveRelUrl = function(url, doc) {
   var docObj = doc || this.$wbwindow.document;
   var parser = this.makeParser(docObj.baseURI, docObj);
-  var hash = parser.href.lastIndexOf('#');
-  var href = hash >= 0 ? parser.href.substring(0, hash) : parser.href;
-  var lastslash = href.lastIndexOf('/');
 
-  if (lastslash >= 0 && lastslash !== href.length - 1) {
-    parser.href = href.substring(0, lastslash + 1) + url;
-  } else {
-    parser.href = href + url;
-  }
-  return parser.href;
+  return new URL(url, parser).href;
 };
 
 /**

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -978,11 +978,11 @@ test('Image: should rewrite image .src correctly, ignoring path in query', async
   const result = await sandbox.evaluate(
     () => {
       const img = new Image(400, 400);
-      img.src = "../../image.png";
+      img.src = '../../image.png';
       return window.WombatTestUtil.getElementPropertyAsIs(img, 'src');
     }
   );
-  t.deepEqual(result, "http://localhost:3030/live/20180803160549im_/https://tests.wombat.io/image.png");
+  t.deepEqual(result, 'http://localhost:3030/live/20180803160549im_/https://tests.wombat.io/image.png');
 });
 
 

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -973,6 +973,20 @@ test('Audio: should rewrite the URL argument to the constructor', async t => {
   t.true(result);
 });
 
+test('Image: should rewrite image .src correctly, ignoring path in query', async t => {
+  const { sandbox, server } = t.context;
+  const result = await sandbox.evaluate(
+    () => {
+      const img = new Image(400, 400);
+      img.src = "../../image.png";
+      return window.WombatTestUtil.getElementPropertyAsIs(img, 'src');
+    }
+  );
+  t.deepEqual(result, "http://localhost:3030/live/20180803160549im_/https://tests.wombat.io/image.png");
+});
+
+
+
 test('FontFace: should rewrite the source argument to the constructor', async t => {
   const { sandbox, server } = t.context;
   await Promise.all([


### PR DESCRIPTION
Use URL constructor for resolving relative URLs instead of manually splitting at last '/'. Avoids issues when resolving URLs
from pages like `https://example.com/path/file.html?url=/alsopath/not/for/relative-url`
bump to 3.6.1