### PR TITLE
Allow wombat configuration to set its own rewriteURL function.

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1926,7 +1926,12 @@ Wombat.prototype.rewriteUrl_ = function(originalURL, useRel, mod, doc) {
  * @return {?string}
  */
 Wombat.prototype.rewriteUrl = function(url, useRel, mod, doc) {
-  var rewritten = this.rewriteUrl_(url, useRel, mod, doc);
+  var rewritten;
+  if (this.wb_info.rewrite_function) {
+    rewritten = this.wb_info.rewrite_function(url, useRel, mod, doc);
+  } else {
+    rewritten = this.rewriteUrl_(url, useRel, mod, doc);
+  }
   if (this.debug_rw) {
     if (url !== rewritten) {
       console.log('REWRITE: ' + url + ' -> ' + rewritten);


### PR DESCRIPTION
If configuration contains a `rewrite_function` it will be used instead of the default one.

This use case is for warc2zim (https://github.com/openzim/warc2zim/pull/139) where we directly rewrite the url applying fuzzy matching.
This would allow use to use wombat without a service worker.