### PR TITLE
Keep existing allowed permissions in appended iframes

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1655,7 +1655,9 @@ Wombat.prototype.rewriteNodeFuncArgs = function(
   }
   var created = originalFn.call(fnThis, newNode, oldNode);
   if (created && created.tagName === 'IFRAME') {
-    created.allow = 'autoplay \'self\'; fullscreen \'self\'';
+    const currentAllow = created.allow ? `; ${created.allow}` : '';
+    created.allow = `autoplay 'self'; fullscreen 'self'${currentAllow}`;
+
     this.initIframeWombat(created);
   }
   return created;

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -836,12 +836,15 @@ test('Node.appendChild: should rewrite a element with multiple children are supp
     const a1 = window.WombatTestUtil.createUntamperedWithElement('a');
     const a2 = window.WombatTestUtil.createUntamperedWithElement('a');
     const a3 = window.WombatTestUtil.createUntamperedWithElement('a');
+    const iframe = window.WombatTestUtil.createUntamperedWithElement('iframe');
     a1.href = 'http://example1.com';
     a2.href = 'http://example2.com';
     a3.href = 'http://example3.com';
+    iframe.allow = 'fullscreen; clipboard-write';
     div.appendChild(a2);
     div.appendChild(a3);
     div.appendChild(a1);
+    div.appendChild(iframe);
     return {
       a1: window.WombatTestUtil.getElementPropertyAsIs(a1, 'href').endsWith(
         'mp_/http://example1.com'
@@ -851,10 +854,12 @@ test('Node.appendChild: should rewrite a element with multiple children are supp
       ),
       a3: window.WombatTestUtil.getElementPropertyAsIs(a3, 'href').endsWith(
         'mp_/http://example3.com'
-      )
+      ),
+      iframe: window.WombatTestUtil.getElementPropertyAsIs(iframe, 'allow')
+        === 'autoplay \'self\'; fullscreen \'self\'; fullscreen; clipboard-write',
     };
   });
-  t.deepEqual(result, { a1: true, a2: true, a3: true });
+  t.deepEqual(result, { a1: true, a2: true, a3: true, iframe: true });
 });
 
 test('Node.insertBefore: should rewrite a element with no children are supplied', async t => {


### PR DESCRIPTION
This PR addresses the issue reported in #133, where any iframe appended to an element via `appendChild()` gets its `allow` attribute overwritten.

With these changes, the base permissions get enhanced with the existing ones.