### PR TITLE
dataset override: add check for property being a string, fixes #132

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3276,7 +3276,7 @@ Wombat.prototype.overrideDataSet = function() {
 
         var result = target[prop];
 
-        if (typeof(result) === "string" && wombat.startsWithOneOf(result, wombat.wb_prefixes)) {
+        if (typeof(result) === 'string' && wombat.startsWithOneOf(result, wombat.wb_prefixes)) {
           return wombat.extractOriginalURL(result);
         }
 

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3276,7 +3276,7 @@ Wombat.prototype.overrideDataSet = function() {
 
         var result = target[prop];
 
-        if (wombat.startsWithOneOf(result, wombat.wb_prefixes)) {
+        if (typeof(result) === "string" && wombat.startsWithOneOf(result, wombat.wb_prefixes)) {
           return wombat.extractOriginalURL(result);
         }
 


### PR DESCRIPTION
Ensure property on `.dataset` is a string before calling startsWithOneOf, otherwise just return default property.
Fixes #132 

The .dataset is a DOMStringMap so only strings should be unrewritten