### PR TITLE
override: add IntersectionObserver(callback, options) constructor override

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -4207,6 +4207,29 @@ Wombat.prototype.initBlobOverride = function() {
   this.$wbwindow.Blob.prototype = orig_blob.prototype;
 };
 
+Wombat.prototype.initIntersectionObsOverride = function() {
+  var orig_iobs = this.$wbwindow.IntersectionObserver;
+
+  var wombat = this;
+
+  this.$wbwindow.IntersectionObserver = (function(IObs) {
+    return function(callback, options) {
+      if (options && options.root) {
+        options.root = wombat.proxyToObj(options.root);
+      }
+
+      return new IObs(callback, options);
+    };
+
+  })(this.$wbwindow.IntersectionObserver);
+
+  this.$wbwindow.IntersectionObserver.prototype = orig_iobs.prototype;
+
+  Object.defineProperty(this.$wbwindow.IntersectionObserver.prototype, 'constructor', {
+    value: this.$wbwindow.IntersectionObserver
+  });
+};
+
 Wombat.prototype.initWSOverride = function() {
   if (!this.$wbwindow.WebSocket || !this.$wbwindow.WebSocket.prototype) {
     return;
@@ -6667,6 +6690,9 @@ Wombat.prototype.wombatInit = function() {
   // ensure _wombat is inited on the iframe $wbwindow!
   this.overrideIframeContentAccess('contentWindow');
   this.overrideIframeContentAccess('contentDocument');
+
+  // IntersectionObserver constructor override
+  this.initIntersectionObsOverride();
 
   // override funcs to convert first arg proxy->obj
   this.overrideFuncArgProxyToObj(this.$wbwindow.MutationObserver, 'observe');


### PR DESCRIPTION
IntersectionObserver(callback, options) has an `options.root` field which may be a `document`, and must be de-proxied.

This PR adds an `initIntersectionObsOverride` override which overrides the `IntersectionObserver` class with a derived class that wraps the original and deproxies `options.root`.

Fixes #136