### PR TITLE
history overrides: add extractOrig in case passed in URL is already r…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3050,6 +3050,8 @@ Wombat.prototype.overrideHistoryFunc = function(funcName) {
     // in case functions rebound to different history obj!
     var historyWin = this.___wb_ownWindow || wombat.$wbwindow;
 
+    url = wombat.extractOriginalURL(url);
+
     var wombatLocation = historyWin.WB_wombat_location;
     var rewritten_url;
     var resolvedURL;


### PR DESCRIPTION
…ewritten, to be more flexible with rewriting issues caused elsewhere

(fixes part of webrecorder/pywb#886)
bump to 3.7.2