### PR TITLE
Fix resolveRelUrl() attempting to use invalid URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -929,7 +929,7 @@ Wombat.prototype.getFinalUrl = function(useRel, mod, url) {
  */
 Wombat.prototype.resolveRelUrl = function(url, doc) {
   var docObj = this.$wbwindow.document;
-  if (doc && doc.baseURI && (doc.startsWith(HTTPS_PREFIX) || doc.startsWith(HTTP_PREFIX))) {
+  if (doc && doc.baseURI && (doc.startsWith(this.HTTPS_PREFIX) || doc.startsWith(this.HTTP_PREFIX))) {
     docObj = doc;
   }
   var parser = this.makeParser(docObj.baseURI, docObj);
@@ -1691,7 +1691,6 @@ Wombat.prototype.rewriteWSURL = function(originalURL) {
   var wsScheme = 'ws://';
   var wssScheme = 'wss://';
 
-  // proxy mode: If no wb_replay_prefix, only rewrite scheme
   // proxy mode: If no wb_replay_prefix, only rewrite scheme
   if (this.wb_is_proxy) {
     if (

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -922,22 +922,31 @@ Wombat.prototype.getFinalUrl = function(useRel, mod, url) {
 };
 
 /**
- * Converts the supplied relative URL to an absolute URL using an A tag
+ * Converts the supplied relative URL to an absolute URL using URL class
  * @param {string} url
  * @param {?Document} doc
  * @return {string}
  */
 Wombat.prototype.resolveRelUrl = function(url, doc) {
-  var docObj = this.$wbwindow.document;
-  if (doc) {
-    var baseURI = doc.baseURI;
-    if (baseURI.startsWith(this.HTTPS_PREFIX) || baseURI.startsWith(this.HTTP_PREFIX)) {
-      docObj = doc;
-    }
-  }
-  var parser = this.makeParser(docObj.baseURI, docObj);
+  var wombat = this;
 
-  return new this.URL(url, parser).href;
+  function isValidBaseURI(doc) {
+    if (!doc || !doc.baseURI) {
+      return false;
+    }
+    return (doc.baseURI.startsWith(wombat.HTTPS_PREFIX) || doc.baseURI.startsWith(wombat.HTTP_PREFIX));
+  }
+
+  var baseURI = null;
+  if (isValidBaseURI(doc)) {
+    baseURI = doc.baseURI;
+  } else if (isValidBaseURI(this.$wbwindow.document)) {
+    baseURI = this.$wbwindow.document.baseURI;
+  } else {
+    baseURI = this.$wbwindow.__WB_replay_top.document.baseURI;
+  }
+
+  return new this.URL(url, baseURI).href;
 };
 
 /**

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -929,8 +929,11 @@ Wombat.prototype.getFinalUrl = function(useRel, mod, url) {
  */
 Wombat.prototype.resolveRelUrl = function(url, doc) {
   var docObj = this.$wbwindow.document;
-  if (doc && doc.baseURI && (doc.baseURI.startsWith(this.HTTPS_PREFIX) || doc.baseURI.startsWith(this.HTTP_PREFIX))) {
-    docObj = doc;
+  if (doc) {
+    var baseURI = doc.baseURI;
+    if (baseURI.startsWith(this.HTTPS_PREFIX) || baseURI.startsWith(this.HTTP_PREFIX)) {
+      docObj = doc;
+    }
   }
   var parser = this.makeParser(docObj.baseURI, docObj);
 

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -928,7 +928,10 @@ Wombat.prototype.getFinalUrl = function(useRel, mod, url) {
  * @return {string}
  */
 Wombat.prototype.resolveRelUrl = function(url, doc) {
-  var docObj = doc || this.$wbwindow.document;
+  var docObj = this.$wbwindow.document;
+  if (doc && doc.baseURI && (doc.startsWith(HTTPS_PREFIX) || doc.startsWith(HTTP_PREFIX))) {
+    docObj = doc;
+  }
   var parser = this.makeParser(docObj.baseURI, docObj);
 
   return new this.URL(url, parser).href;

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -929,7 +929,7 @@ Wombat.prototype.getFinalUrl = function(useRel, mod, url) {
  */
 Wombat.prototype.resolveRelUrl = function(url, doc) {
   var docObj = this.$wbwindow.document;
-  if (doc && doc.baseURI && (doc.startsWith(this.HTTPS_PREFIX) || doc.startsWith(this.HTTP_PREFIX))) {
+  if (doc && doc.baseURI && (doc.baseURI.startsWith(this.HTTPS_PREFIX) || doc.baseURI.startsWith(this.HTTP_PREFIX))) {
     docObj = doc;
   }
   var parser = this.makeParser(docObj.baseURI, docObj);


### PR DESCRIPTION
- just use URL class instead of <a> element for absolute URL resolving (removing old code)
- specifically check baseURI for https:// or http://
- only use valid http/https baseURI as base rewriting URL
- if passed in doc doesn't have an http/https base URI, check window document, then replay-top document.
- fixes #139 
- fixes webrecorder/replayweb.page#300
- bump version to 3.7.3