### PR TITLE
rewrite fixes: convert <object> with image/svg+xml to <img> tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",


### PR DESCRIPTION
- when in service worker mode, convert `<object type="image/svg+xml" data=...>` to `<img src=...>`, since service worker does not intercept object tags.
- also override XMLHttpRequest.setAttributionReporting() to nop
- add a deproxy for rewriteAttr
- fixes replay of https://www.educative.io/courses/grokking-modern-system-design-interview-for-engineers-managers/how-the-domain-name-system-works (webrecorder/archiveweb.page#201)