### PR TITLE
Rewrite fix 3.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2010,7 +2010,7 @@ Wombat.prototype.performAttributeRewrite = function(
  */
 Wombat.prototype.rewriteAttr = function(elem, name, absUrlOnly) {
   var changed = false;
-  if (!elem || !elem.getAttribute || elem._no_rewrite || elem['_' + name] || (elem.tagName && elem.tagName.indexOf("-") > 0)) {
+  if (!elem || !elem.getAttribute || elem._no_rewrite || elem['_' + name] || (elem.tagName && elem.tagName.indexOf('-') > 0)) {
     return changed;
   }
 
@@ -6303,7 +6303,7 @@ Wombat.prototype.initWindowObjProxy = function($wbwindow) {
       },
       defineProperty: function(target, prop, desc) {
         var ndesc = desc || {};
-        if (ndesc.value === undefined && ndesc.get === undefined) {
+        if (!ndesc.hasOwnProperty('value') && !ndesc.hasOwnProperty('get') && !ndesc.hasOwnProperty('set')) {
           ndesc.value = $wbwindow[prop];
         }
         Reflect.defineProperty($wbwindow, prop, ndesc);
@@ -6800,7 +6800,7 @@ Wombat.prototype.wombatInit = function() {
     'dispatchEvent'
   );
 
-  this.overrideDeProxyPropAssign(this.$wbwindow.TreeWalker.prototype, "currentNode");
+  this.overrideDeProxyPropAssign(this.$wbwindow.TreeWalker.prototype, 'currentNode');
 
   this.initTimeoutIntervalOverrides();
 


### PR DESCRIPTION
- deproxy assignment to TreeWalker.currentNode
- ensure generic attributes (src and href) are *not* rewritten on custom web-component elements (elements that contain a '-')
- add nop override for navigator.getInstalledRelatedApps() if it is defined
- Proxy defineProperty: don't pull in value from object if either getter or setter are provided
- bump to 3.7.6
- fixes to support reddit replay, ebay carousel