### PR TITLE
rewrite: uses wombat.URL instead of window.URL to avoid infinite loop…

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1061,7 +1061,7 @@ Wombat.prototype.makeParser = function(maybeRewrittenURL, doc) {
 
 Wombat.prototype._makeURLParser = function(url, docElem) {
   try {
-    return new this.$wbwindow.URL(url, docElem.baseURI);
+    return new this.URL(url, docElem.baseURI);
   } catch (e) {}
 
   var p = docElem.createElement('a');


### PR DESCRIPTION
… when window.URL is replaced with custom function (fixes webrecorder/replayweb.page#330)