### PR TITLE
Func bind copy own props

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1429,13 +1429,21 @@ Wombat.prototype.defaultProxyGet = function(obj, prop, ownProps, fnCache) {
     // we must return the
     var cachedFN = fnCache[prop];
     if (!cachedFN || cachedFN.original !== retVal) {
-      cachedFN = {
+      const boundFn = retVal.bind(obj);
+      const SKIP_OWN_PROPS = ["name", "length", "__WB_is_native_func__"];
+      for (const ownProp of Object.getOwnPropertyNames(retVal)) {
+        if (!SKIP_OWN_PROPS.includes(ownProp)) {
+          boundFn[ownProp] = retVal[ownProp];
+        }
+      }
+      fnCache[prop] = {
         original: retVal,
-        boundFn: retVal.bind(obj)
+        boundFn
       };
-      fnCache[prop] = cachedFN;
+      return boundFn;
     }
     return cachedFN.boundFn;
+
   } else if (type === 'object' && retVal && retVal._WB_wombat_obj_proxy) {
     if (retVal instanceof this.WBWindow) {
       this.initNewWindowWombat(retVal);

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1430,7 +1430,7 @@ Wombat.prototype.defaultProxyGet = function(obj, prop, ownProps, fnCache) {
     var cachedFN = fnCache[prop];
     if (!cachedFN || cachedFN.original !== retVal) {
       const boundFn = retVal.bind(obj);
-      const SKIP_OWN_PROPS = ["name", "length", "__WB_is_native_func__"];
+      const SKIP_OWN_PROPS = ['name', 'length', '__WB_is_native_func__'];
       for (const ownProp of Object.getOwnPropertyNames(retVal)) {
         if (!SKIP_OWN_PROPS.includes(ownProp)) {
           boundFn[ownProp] = retVal[ownProp];


### PR DESCRIPTION
When binding to this (to add deproxying), ensure any custom properties added to function object are also copied over.

Fixes: replay of https://www.airbnb.com/