### PR TITLE
proxy: bind() use rewritten apply if native function, otherwise original to avoid unnecessary deproxying

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -3578,7 +3578,7 @@ Wombat.prototype.overrideFunctionBind = function($wbwindow) {
   var wombat = this;
   $wbwindow.Function.prototype.bind = function bind(obj) {
     var isNative = wombat.isNativeFunction(this);
-    var result = this.__WB_orig_bind.apply(this, arguments);
+    var result = isNative ? this.__WB_orig_bind.apply(this, arguments) : this.__WB_orig_bind.__WB_orig_apply(this, arguments);
     result.__WB_is_native_func__ = isNative;
     return result;
   };


### PR DESCRIPTION
before this fix, something like:

```
let window = <proxy override>
let document = <proxy override>
...
let d = document;
let w = window;

let f = function(w, d) {
}.bind(this)
```

would result in `w` and `d` in `f` being de-proxied. This fixes this unneeded deproxying