### PR TITLE
support postMessage(msg, options)

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5714,7 +5714,7 @@ Wombat.prototype.initPostMessageOverride = function($wbwindow) {
 
     var targetOrigin;
 
-    if (typeof(targetOrigin_or_options) === "object") {
+    if (typeof(targetOrigin_or_options) === 'object') {
       targetOrigin = targetOrigin_or_options.targetOrigin;
       transfer = targetOrigin_or_options.transfer;
     } else {

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5678,7 +5678,7 @@ Wombat.prototype.initPostMessageOverride = function($wbwindow) {
   // use this_obj.__WB_source not window to fix google calendar embeds, pm_origin sets this.__WB_source
   var postmessage_rewritten = function postMessage(
     message,
-    targetOrigin,
+    targetOrigin_or_options,
     transfer,
     from_top
   ) {
@@ -5710,6 +5710,15 @@ Wombat.prototype.initPostMessageOverride = function($wbwindow) {
       this_obj.__WB_source = undefined;
     } else {
       from = window.WB_wombat_location.origin;
+    }
+
+    var targetOrigin;
+
+    if (typeof(targetOrigin_or_options) === "object") {
+      targetOrigin = targetOrigin_or_options.targetOrigin;
+      transfer = targetOrigin_or_options.transfer;
+    } else {
+      targetOrigin = targetOrigin_or_options;
     }
 
     var to_origin = targetOrigin;


### PR DESCRIPTION
Support `postMessage(msg, options)` form of postMessage and convert to `postMessage(msg, targetOrigin, transfer)` on rewrite. Fixes #156 