### PR TITLE
follow-up to #161:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.7.9",
+  "version": "3.7.10",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",


### PR DESCRIPTION
- add __WB_no_unrewrite option to get original url / referrer
- avoids storing extra real URL, extra copying of RequestInit object
- simplifies Request override, avoids copying props (fixes body not being copied)
- bump to 3.7.10