### PR TITLE
Fix regression in <object> tag rewriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.7.12",
+  "version": "3.7.13",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -2277,19 +2277,21 @@ Wombat.prototype.rewriteElem = function(elem) {
             altElemName = 'IMG';
           }
 
-          var newElem = this.$wbwindow.document.createElement(altElemName);
-          for (var i = 0; i < elem.attributes.length; i++) {
-            var attr = elem.attributes[i];
-            var name = attr.name;
-            if (name === 'data') {
-              name = 'src';
+          if (altElemName) {
+            var newElem = this.$wbwindow.document.createElement(altElemName);
+            for (var i = 0; i < elem.attributes.length; i++) {
+              var attr = elem.attributes[i];
+              var name = attr.name;
+              if (name === 'data') {
+                name = 'src';
+              }
+              this.wb_setAttribute.call(newElem, name, attr.value);
             }
-            this.wb_setAttribute.call(newElem, name, attr.value);
-          }
 
-          elem.parentElement.replaceChild(newElem, elem);
-          changed = true;
-          break;
+            elem.parentElement.replaceChild(newElem, elem);
+            changed = true;
+            break;
+          }
         }
 
         changed = this.rewriteAttr(elem, 'data', true);


### PR DESCRIPTION
If no rewriting is needed, still create <object> tag, instead of 'undefined'

bump to 3.7.13