### PR TITLE
rewrite: support excluding wrapper variables from being added, if an …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.7.13",
+  "version": "3.7.14",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",


### PR DESCRIPTION
…existing declaration already exists, eg. if 'var document = ' is found,

don't add a 'let document = ' override
bump to 3.7.14