### PR TITLE
Support 'convert-post-to-get-in-xhr' without service worker

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,8 +29,6 @@ jobs:
     - run: yarn run build-full-test
     - id: setup-chrome
       uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: 128
     # set up a virtual display for chrome (since the tests don't currently run it in headless mode)
     # then run the tests
     - name: Run Tests

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,10 @@ jobs:
     - uses: browser-actions/setup-chrome@v1
     # set up a virtual display for chrome (since the tests don't currently run it in headless mode)
     # then run the tests
-    - run: |
+    - name: Run Tests
+      env:
+        CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+      run: |
         export DISPLAY=:99
         sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-        CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }} yarn test
+        yarn test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,8 @@ jobs:
     - run: yarn run build-full-test
     - id: setup-chrome
       uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: 128
     # set up a virtual display for chrome (since the tests don't currently run it in headless mode)
     # then run the tests
     - name: Run Tests

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,8 @@ jobs:
         node-version: 18.x
     - run: yarn install
     - run: yarn run build-full-test
-    - uses: browser-actions/setup-chrome@v1
+    - id: setup-chrome
+      uses: browser-actions/setup-chrome@v1
     # set up a virtual display for chrome (since the tests don't currently run it in headless mode)
     # then run the tests
     - name: Run Tests

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,4 +33,4 @@ jobs:
     - run: |
         export DISPLAY=:99
         sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-        yarn test
+        CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }} yarn test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,6 +27,7 @@ jobs:
         node-version: 18.x
     - run: yarn install
     - run: yarn run build-full-test
+    - uses: browser-actions/setup-chrome@v1
     # set up a virtual display for chrome (since the tests don't currently run it in headless mode)
     # then run the tests
     - run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -4549,7 +4549,9 @@ Wombat.prototype.initHTTPOverrides = function() {
     // responseURL override
   this.overridePropExtract(this.$wbwindow.XMLHttpRequest.prototype, 'responseURL');
 
-  if (!this.wb_info.isSW) {
+  var convertToGet = !!this.wb_info.convert_post_to_get;
+
+  if (!this.wb_info.isSW && !convertToGet) {
     if (this.$wbwindow.XMLHttpRequest.prototype.open) {
       var origXMLHttpOpen = this.$wbwindow.XMLHttpRequest.prototype.open;
       this.utilFns.XHRopen = origXMLHttpOpen;
@@ -4587,9 +4589,6 @@ Wombat.prototype.initHTTPOverrides = function() {
     this.$wbwindow.XMLHttpRequest.prototype.setRequestHeader = function(name, value) {
       this.__WB_xhr_headers.set(name, value);
     };
-
-    var wombat = this;
-    var convertToGet = !!this.wb_info.convert_post_to_get;
 
     this.$wbwindow.XMLHttpRequest.prototype.send = async function(value) {
       if (convertToGet && (this.__WB_xhr_open_arguments[0] === 'POST' || this.__WB_xhr_open_arguments[0] === 'PUT')) {


### PR DESCRIPTION
Ensure XHR override is applied even if not using service worker if 'convert post to get' is true, fixes #158 
bump to 3.8.4
ci: attempt to fix errant test failures than pop up on ci