### PR TITLE
override: add override to getRootNode() to return proxy object, fixes #183

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5027,6 +5027,14 @@ Wombat.prototype.initDomOverride = function() {
       'parentNode'
     );
     this.overridePropToProxy(this.$wbwindow.Event.prototype, 'target');
+
+    // getRootNode() override
+    var orig_getRootNode = Node.prototype.getRootNode;
+    var wombat = this;
+
+    Node.prototype.getRootNode = function() {
+      return wombat.objToProxy(orig_getRootNode.call(this));
+    }
   }
 
   if (this.$wbwindow.Element && this.$wbwindow.Element.prototype) {


### PR DESCRIPTION
return proxies object (document) from getRootNode() to ensure issues where `document === elem.getRootNode()` might fail, fixes #183 