### PR TITLE
support for ESM worker + import + eval fixes:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",


### PR DESCRIPTION
- if new Worker(url, {type: module}), then use 'wkrm_' modifier
- rewrite 'import' -> '____wb_rewrite_import__' in all eval(), can be used in non-module as well
- correctly rewrite 'import(url)' used in non-modules
- bump to 3.8.9