### PR TITLE
Importmap rewriting fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wombat",
-  "version": "3.8.12",
+  "version": "3.8.13",
   "main": "index.js",
   "license": "AGPL-3.0-or-later",
   "author": "Ilya Kreymer, Webrecorder Software",


### PR DESCRIPTION
rewriting: for esm imports, don't apply rewriting if specified url/key is already mapped via an importmap
(check and parse all importmaps to see if key matches an exact import or a scope)
part of fix for webrecorder/replayweb.page#421
bump to 3.8.13