### PR TITLE
Fix proxy invariant error for frozen document methods

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1436,7 +1436,12 @@ Wombat.prototype.defaultProxyGet = function(obj, prop, ownProps, fnCache) {
   var propDesc = Object.getOwnPropertyDescriptor(obj, prop);
 
   // Frozen own data properties must be returned as-is to satisfy Proxy invariants.
-  if (propDesc && !propDesc.configurable && propDesc.writable === false) {
+  if (
+    propDesc !== undefined &&       // If it's an own property, and
+    'value' in propDesc &&          // is a data property, and
+    propDesc.writable === false &&  // is non-writable, and
+    propDesc.configurable === false // is non-configurable
+  ) {
     return retVal;
   }
 

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -1433,6 +1433,12 @@ Wombat.prototype.defaultProxyGet = function(obj, prop, ownProps, fnCache) {
       return obj.constructor;
   }
   var retVal = Reflect.get(obj, prop);
+  var propDesc = Object.getOwnPropertyDescriptor(obj, prop);
+
+  // Frozen own data properties must be returned as-is to satisfy Proxy invariants.
+  if (propDesc && !propDesc.configurable && propDesc.writable === false) {
+    return retVal;
+  }
 
   var type = typeof retVal;
 

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -24,10 +24,11 @@ test.beforeEach(async t => {
   t.context.sandbox = helper.sandbox();
   t.context.server = helper.server();
   t.context.testPage = helper.testPage();
+  t.context.fullRefresh = false;
 });
 
 test.afterEach.always(async t => {
-  if (t.title.includes('SharedWorker')) {
+  if (t.title.includes('SharedWorker') || t.context.fullRefresh) {
     await helper.fullRefresh();
   } else {
     await helper.ensureSandbox();
@@ -66,6 +67,28 @@ test('anchor links should not be broken by wombat', async t => {
     return a.href;
   });
   t.is(actual, 'https://tests.wombat.io/#anchor');
+});
+
+test('document.createElement: should not throw for frozen overrides', async t => {
+  const { sandbox } = t.context;
+  t.context.fullRefresh = true;
+  const tagName = await sandbox.evaluate(() => {
+    const proxiedDocument = document._WB_wombat_obj_proxy;
+    const originalCreateElement = proxiedDocument.createElement;
+
+    function createElement(tagName, options) {
+      return originalCreateElement.call(proxiedDocument, tagName, options);
+    }
+
+    Object.defineProperty(proxiedDocument, 'createElement', {
+      value: createElement,
+      configurable: false,
+      writable: false
+    });
+
+    return proxiedDocument.createElement('div').tagName;
+  });
+  t.is(tagName, 'DIV');
 });
 
 test('document.title: should send the "title" message to the top frame when document.title is changed', async t => {


### PR DESCRIPTION
Return frozen own data properties unchanged from defaultProxyGet so document proxy reads do not throw due to violating Proxy invariants on sites like Wix that replace methods like document.createElement with a non-configurable, read-only override.

Adds a regression test for the document.createElement example.

Fixes #221