### PR TITLE
Fix parser-time document.write() in service worker mode

### DIFF
--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5324,6 +5324,7 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
   var $wbDocument = this.$wbwindow.document;
 
   this._writeBuff = '';
+  this._docOpenReplacedDocument = false;
 
   var wombat = this;
 
@@ -5410,9 +5411,16 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       res = orig_doc_open.call(thisObj, rwUrl, arguments[1], arguments[2]);
       wombat.initNewWindowWombat(res, arguments[0]);
     } else {
+      const oldDocumentElement = thisObj.documentElement;
       res = orig_doc_open.call(thisObj);
       if (isSWLoad()) {
-        wombat._writeBuff = '';
+        // Track whether the native call replaced the document so close() can
+        // use the blob workaround.
+        wombat._docOpenReplacedDocument =
+          !oldDocumentElement || thisObj.documentElement !== oldDocumentElement;
+        if (wombat._docOpenReplacedDocument) {
+          wombat._writeBuff = '';
+        }
       } else {
         wombat.initNewWindowWombat(thisObj.defaultView);
       }
@@ -5428,14 +5436,30 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
   var originalClose = $wbDocument.close;
   var newClose = function close() {
     if (wombat._writeBuff) {
+      const wasLoading = this.readyState === 'loading';
+      let nativeWriteReplacedDocument = false;
+
       // if loading, apply as may be sync waiting for changes
-      if (this.readyState === 'loading') {
+      if (wasLoading) {
+        const oldDocumentElement = $wbDocument.documentElement;
         orig_doc_write.call(
           $wbDocument,
           wombat.rewriteHtml(wombat._writeBuff, true)
         );
+        nativeWriteReplacedDocument =
+          oldDocumentElement !== null &&
+          $wbDocument.documentElement !== oldDocumentElement;
       }
-      if (isSWLoad()) {
+      // Chromium has an issue where it does not route requests from replaced
+      // iframe documents to the service worker, so as a workaround if
+      // document.write() or document.open() replaced the document we create a
+      // blob URL from the buffer contents and navigate the iframe to it.
+      if (
+        isSWLoad() &&
+        (!wasLoading ||
+          wombat._docOpenReplacedDocument ||
+          nativeWriteReplacedDocument)
+      ) {
         wombat.blobUrlForIframe(
           wombat.$wbwindow.frameElement,
           wombat._writeBuff
@@ -5459,8 +5483,10 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
         }
       }
       wombat._writeBuff = '';
+      wombat._docOpenReplacedDocument = false;
       return;
     }
+    wombat._docOpenReplacedDocument = false;
     var thisObj = wombat.proxyToObj(this);
     wombat.initNewWindowWombat(thisObj.defaultView);
     if (originalClose.__WB_orig_apply) {

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5324,7 +5324,6 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
   var $wbDocument = this.$wbwindow.document;
 
   this._writeBuff = '';
-  this._docOpenReplacedDocument = false;
 
   var wombat = this;
 
@@ -5413,11 +5412,9 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
     } else {
       res = orig_doc_open.call(thisObj);
       if (isSWLoad()) {
-        // Track whether the native call replaced the document so close() can
-        // use the blob workaround.
+        // only clear writeBuff if open() cleared the document, eg. starting a new document
         if (!thisObj.documentElement) {
           wombat._writeBuff = '';
-          wombat._docOpenReplacedDocument = true;
         }
       } else {
         wombat.initNewWindowWombat(thisObj.defaultView);
@@ -5438,9 +5435,7 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       // injectDocClose means that document.write('<script>...</script>')
       // will call this function again before the first call returns.
       const writeBuff = wombat._writeBuff;
-      const docOpenReplacedDocument = wombat._docOpenReplacedDocument;
       wombat._writeBuff = '';
-      wombat._docOpenReplacedDocument = false;
 
       const wasLoading = this.readyState === 'loading';
       let nativeWriteReplacedDocument = false;
@@ -5462,7 +5457,6 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       if (
         isSWLoad() &&
         (!wasLoading ||
-          docOpenReplacedDocument ||
           nativeWriteReplacedDocument)
       ) {
         wombat.blobUrlForIframe(wombat.$wbwindow.frameElement, writeBuff);
@@ -5486,7 +5480,6 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       }
       return;
     }
-    wombat._docOpenReplacedDocument = false;
     var thisObj = wombat.proxyToObj(this);
     wombat.initNewWindowWombat(thisObj.defaultView);
     if (originalClose.__WB_orig_apply) {

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5411,15 +5411,13 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       res = orig_doc_open.call(thisObj, rwUrl, arguments[1], arguments[2]);
       wombat.initNewWindowWombat(res, arguments[0]);
     } else {
-      const oldDocumentElement = thisObj.documentElement;
       res = orig_doc_open.call(thisObj);
       if (isSWLoad()) {
         // Track whether the native call replaced the document so close() can
         // use the blob workaround.
-        wombat._docOpenReplacedDocument =
-          !oldDocumentElement || thisObj.documentElement !== oldDocumentElement;
-        if (wombat._docOpenReplacedDocument) {
+        if (!thisObj.documentElement) {
           wombat._writeBuff = '';
+          wombat._docOpenReplacedDocument = true;
         }
       } else {
         wombat.initNewWindowWombat(thisObj.defaultView);
@@ -5447,7 +5445,6 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
           wombat.rewriteHtml(wombat._writeBuff, true)
         );
         nativeWriteReplacedDocument =
-          oldDocumentElement !== null &&
           $wbDocument.documentElement !== oldDocumentElement;
       }
       // Chromium has an issue where it does not route requests from replaced

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5430,6 +5430,7 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
   // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-close
   var originalClose = $wbDocument.close;
   var newClose = function close() {
+    var thisObj = wombat.proxyToObj(this);
     if (wombat._writeBuff) {
       // Clear the global state before calling the native orig_doc_write because
       // injectDocClose means that document.write('<script>...</script>')
@@ -5439,22 +5440,22 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
 
       let nativeWriteReplacedDocument = false;
 
-      // if loading, call write() immediately as not necessarily replacing the doc
-      // and may be waiting for results of write
-      if (this.readyState === 'loading') {
-        const oldDocumentElement = $wbDocument.documentElement;
-        orig_doc_write.call(
-          $wbDocument,
-          wombat.rewriteHtml(writeBuff, true)
-        );
-        nativeWriteReplacedDocument =
-          $wbDocument.documentElement !== oldDocumentElement;
-      } else {
-        // if write called outside of 'loading' state, document has already been replaced
-        nativeWriteReplacedDocument = true;
-      }
+      // possible options here are:
+      //
+      // 1) initial page load: oldDocumentElement is non-null, calling write doesn't change element
+      // 2) new document: doc.open(), doc.write() and then doc.close() called:
+      //    oldDocumentElement is null, replaced with new document
+      // 3) new document: doc.write() and doc.close() called without doc.open()
+      //    oldDocumentElement is non-null old doc, replaced with new document
 
-      // Chromium has an issue where it does not route requests from replaced
+      // First, always call native .write() and .close() as sync code may attempt to access
+      // then new document after .close()
+      const oldDocumentElement = thisObj.documentElement;
+      orig_doc_write.call(thisObj, wombat.rewriteHtml(writeBuff, true));
+      nativeWriteReplacedDocument =
+        thisObj.documentElement !== oldDocumentElement;
+
+      // Chromium and sometimes Firefox have an issue where it does not route requests from replaced
       // iframe documents to the service worker, so as a workaround if
       // document.write() or document.open() replaced the document we create a
       // blob URL from the buffer contents and navigate the iframe to it.
@@ -5480,7 +5481,6 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       }
       return;
     }
-    var thisObj = wombat.proxyToObj(this);
     wombat.initNewWindowWombat(thisObj.defaultView);
     if (originalClose.__WB_orig_apply) {
       return originalClose.__WB_orig_apply(thisObj, arguments);

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5434,6 +5434,14 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
   var originalClose = $wbDocument.close;
   var newClose = function close() {
     if (wombat._writeBuff) {
+      // Clear the global state before calling the native orig_doc_write because
+      // injectDocClose means that document.write('<script>...</script>')
+      // will call this function again before the first call returns.
+      const writeBuff = wombat._writeBuff;
+      const docOpenReplacedDocument = wombat._docOpenReplacedDocument;
+      wombat._writeBuff = '';
+      wombat._docOpenReplacedDocument = false;
+
       const wasLoading = this.readyState === 'loading';
       let nativeWriteReplacedDocument = false;
 
@@ -5442,7 +5450,7 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
         const oldDocumentElement = $wbDocument.documentElement;
         orig_doc_write.call(
           $wbDocument,
-          wombat.rewriteHtml(wombat._writeBuff, true)
+          wombat.rewriteHtml(writeBuff, true)
         );
         nativeWriteReplacedDocument =
           $wbDocument.documentElement !== oldDocumentElement;
@@ -5454,13 +5462,10 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       if (
         isSWLoad() &&
         (!wasLoading ||
-          wombat._docOpenReplacedDocument ||
+          docOpenReplacedDocument ||
           nativeWriteReplacedDocument)
       ) {
-        wombat.blobUrlForIframe(
-          wombat.$wbwindow.frameElement,
-          wombat._writeBuff
-        );
+        wombat.blobUrlForIframe(wombat.$wbwindow.frameElement, writeBuff);
 
         const doc = this;
 
@@ -5479,8 +5484,6 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
           // ignore
         }
       }
-      wombat._writeBuff = '';
-      wombat._docOpenReplacedDocument = false;
       return;
     }
     wombat._docOpenReplacedDocument = false;

--- a/src/wombat.js
+++ b/src/wombat.js
@@ -5437,11 +5437,11 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
       const writeBuff = wombat._writeBuff;
       wombat._writeBuff = '';
 
-      const wasLoading = this.readyState === 'loading';
       let nativeWriteReplacedDocument = false;
 
-      // if loading, apply as may be sync waiting for changes
-      if (wasLoading) {
+      // if loading, call write() immediately as not necessarily replacing the doc
+      // and may be waiting for results of write
+      if (this.readyState === 'loading') {
         const oldDocumentElement = $wbDocument.documentElement;
         orig_doc_write.call(
           $wbDocument,
@@ -5449,16 +5449,16 @@ Wombat.prototype.initDocWriteOpenCloseOverride = function() {
         );
         nativeWriteReplacedDocument =
           $wbDocument.documentElement !== oldDocumentElement;
+      } else {
+        // if write called outside of 'loading' state, document has already been replaced
+        nativeWriteReplacedDocument = true;
       }
+
       // Chromium has an issue where it does not route requests from replaced
       // iframe documents to the service worker, so as a workaround if
       // document.write() or document.open() replaced the document we create a
       // blob URL from the buffer contents and navigate the iframe to it.
-      if (
-        isSWLoad() &&
-        (!wasLoading ||
-          nativeWriteReplacedDocument)
-      ) {
+      if (isSWLoad() && nativeWriteReplacedDocument) {
         wombat.blobUrlForIframe(wombat.$wbwindow.frameElement, writeBuff);
 
         const doc = this;

--- a/test/assets/docWriteFrame.html
+++ b/test/assets/docWriteFrame.html
@@ -17,7 +17,7 @@
   <body>
     1
     <script>
-      document.write('2');
+      document.write('<script>document.write("2")<\/script>');
       document.close();
     </script>
     3

--- a/test/assets/docWriteFrame.html
+++ b/test/assets/docWriteFrame.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>document.write() test frame</title>
+    <script>
+      window.wbinfo = Object.assign({}, parent.wbinfo, {
+        isSW: true,
+        injectDocClose: true
+      });
+    </script>
+    <script src="/wombat.js"></script>
+    <script>
+      window._WBWombatInit(window.wbinfo);
+    </script>
+  </head>
+  <body>
+    1
+    <script>
+      document.write('2');
+      document.close();
+    </script>
+    3
+    <script>
+      document.write('4');
+      document.close();
+    </script>
+  </body>
+</html>

--- a/test/helpers/initServer.js
+++ b/test/helpers/initServer.js
@@ -10,6 +10,7 @@ const assetsPath = path.join(__dirname, '..', 'assets');
 const httpsSandboxPath = path.join(assetsPath, 'sandbox.html');
 const sandboxDirectPath = path.join(assetsPath, 'sandboxDirect.html');
 const theyFoundItPath = path.join(assetsPath, 'it.html');
+const docWriteFramePath = path.join(assetsPath, 'docWriteFrame.html');
 
 const testPageURL = `http://localhost:${port}/testPage.html`;
 const testPageDirectURL = `http://localhost:${port}/testPageDirect.html`;
@@ -83,6 +84,15 @@ async function initServer() {
           .type('text/html')
           .status(200)
           .send(fs.createReadStream(theyFoundItPath));
+      }
+    )
+    .get(
+      '/live/20180803160549if_/https://tests.wombat.io/docWriteFrame.html',
+      (request, reply) => {
+        reply
+          .type('text/html')
+          .status(200)
+          .send(fs.createReadStream(docWriteFramePath));
       }
     )
     .get(

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -327,6 +327,22 @@ test('document.write: should perform rewriting with multiple write calls, each i
   );
 });
 
+test('document.write: should insert at the parser position in SW mode', async t => {
+  const result = await t.context.sandbox.evaluate(
+    () =>
+      new Promise(resolve => {
+        const iframe = document.createElement('iframe');
+        iframe.onload = () => {
+          resolve(iframe.contentDocument.body.innerText.replace(/\s/g, ''));
+          iframe.remove();
+        };
+        iframe.src = 'http://localhost:3030/docWriteFrame.html';
+        document.body.appendChild(iframe);
+      })
+  );
+  t.is(result, '1234');
+});
+
 test('document.writeln: should not perform rewriting when "writeln" is called with no arguments', async t => {
   const { sandbox, testPage } = t.context;
   await sandbox.evaluate(() => {

--- a/test/overrides-dom.js
+++ b/test/overrides-dom.js
@@ -330,9 +330,14 @@ test('document.write: should perform rewriting with multiple write calls, each i
 test('document.write: should insert at the parser position in SW mode', async t => {
   const result = await t.context.sandbox.evaluate(
     () =>
-      new Promise(resolve => {
+      new Promise((resolve, reject) => {
         const iframe = document.createElement('iframe');
+        const timeout = setTimeout(() => {
+          iframe.remove();
+          reject(new Error('document.write iframe timed out'));
+        }, 3000);
         iframe.onload = () => {
+          clearTimeout(timeout);
           resolve(iframe.contentDocument.body.innerText.replace(/\s/g, ''));
           iframe.remove();
         };


### PR DESCRIPTION
The blob URL workaround for iframe documents was also applied to document.write() calls made during parsing time causing the existing document content to be discarded.

Only use the blob workaround when document.open() or document.write() actually replace the document.

Fixes #234

---

With this patch the test case from #234, the Sydney 2000 Olympics site and https://h5p.org/presentation all work.